### PR TITLE
PHP Warning:  Module 'PDO' already loaded in Unknown on line 0

### DIFF
--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -6,7 +6,7 @@ RUN a2enmod rewrite
 RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
-	&& docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql
+	&& docker-php-ext-install gd mbstring pdo_mysql pdo_pgsql
 
 WORKDIR /var/www/html
 

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -6,7 +6,7 @@ RUN a2enmod rewrite
 RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
-	&& docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql
+	&& docker-php-ext-install gd mbstring pdo_mysql pdo_pgsql
 
 WORKDIR /var/www/html
 


### PR DESCRIPTION
PDO ships with PHP 5.1 -- http://php.net/manual/en/intro.pdo.php

So the pecl extension is not required.