### PR TITLE
Update Dockerfile to install PHP zip extension

### DIFF
--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -7,7 +7,7 @@ RUN a2enmod rewrite
 RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
-	&& docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql
+	&& docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip
 
 WORKDIR /var/www/html
 

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -7,7 +7,7 @@ RUN a2enmod rewrite
 RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
-	&& docker-php-ext-install gd mbstring opcache pdo pdo_mysql pdo_pgsql
+	&& docker-php-ext-install gd mbstring opcache pdo pdo_mysql pdo_pgsql zip
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php


### PR DESCRIPTION
Drupal uses Composer a lot; especially Drupal 8, and there are a lot of modules, requiring composer, are being back ported to Drupal 7. Composer use PHP zip extension. Otherwise, see https://github.com/docker-library/php/issues/60