### PR TITLE
Use PHP 7 for Drupal 8 going forward

### DIFF
--- a/8/apache/Dockerfile
+++ b/8/apache/Dockerfile
@@ -1,5 +1,5 @@
 # from https://www.drupal.org/requirements/php#drupalversions
-FROM php:5.6-apache
+FROM php:7-apache
 
 RUN a2enmod rewrite
 

--- a/8/fpm/Dockerfile
+++ b/8/fpm/Dockerfile
@@ -1,5 +1,5 @@
 # from https://www.drupal.org/requirements/php#drupalversions
-FROM php:5.6-fpm
+FROM php:7-fpm
 
 # install the PHP extensions we need
 RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev \


### PR DESCRIPTION
Here is why: http://fabianx.drupalgardens.com/blog/why-drupal-8-defaulting-its-testing-php7-and-why-you-should-too

And the current status of PHP 7 Support in D8: 

> Drupal 8 currently has 100% pass on PHP 7
https://www.drupal.org/node/2454439