### PR TITLE
Switch Drupal 7 PHP version to 7

### DIFF
--- a/7/apache/Dockerfile
+++ b/7/apache/Dockerfile
@@ -1,5 +1,5 @@
 # from https://www.drupal.org/requirements/php#drupalversions
-FROM php:5.6-apache
+FROM php:7.0-apache
 
 RUN a2enmod rewrite
 

--- a/7/fpm/Dockerfile
+++ b/7/fpm/Dockerfile
@@ -1,5 +1,5 @@
 # from https://www.drupal.org/requirements/php#drupalversions
-FROM php:5.6-fpm
+FROM php:7.0-fpm
 
 # install the PHP extensions we need
 RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev libpq-dev \


### PR DESCRIPTION
> Improved support for recent PHP versions, including PHP 7
> 
> Drupal core's automated test suite is now fully passing on a variety of environments where there were previously some failures (PHP 5.4, 5.5, 5.6, and 7). We have also fixed several bugs affecting those versions. These PHP versions are officially supported by Drupal 7 and recommended for use where possible.
> 
> Because PHP 7 is the newest release (and not yet used on many production sites) extra care should still be taken with it, and there are some known bugs, especially in contributed modules (see the discussion for more details). However anecdotal evidence from a variety of users suggests that Drupal 7 can be successfully used on PHP 7, both before and after the 7.50 release.

https://www.drupal.org/requirements/php and https://www.drupal.org/node/2656548