### PR TITLE
Fix Drupal 8 default folder permission

### DIFF
--- a/8.1/apache/Dockerfile
+++ b/8.1/apache/Dockerfile
@@ -30,4 +30,4 @@ RUN curl -fSL "http://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar
 	&& echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c - \
 	&& tar -xz --strip-components=1 -f drupal.tar.gz \
 	&& rm drupal.tar.gz \
-	&& chown -R www-data:www-data sites
+	&& chown -R www-data:www-data sites modules themes

--- a/8.1/fpm/Dockerfile
+++ b/8.1/fpm/Dockerfile
@@ -28,4 +28,4 @@ RUN curl -fSL "http://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar
 	&& echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c - \
 	&& tar -xz --strip-components=1 -f drupal.tar.gz \
 	&& rm drupal.tar.gz \
-	&& chown -R www-data:www-data sites
+	&& chown -R www-data:www-data sites modules themes

--- a/8.2/apache/Dockerfile
+++ b/8.2/apache/Dockerfile
@@ -30,4 +30,4 @@ RUN curl -fSL "http://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar
 	&& echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c - \
 	&& tar -xz --strip-components=1 -f drupal.tar.gz \
 	&& rm drupal.tar.gz \
-	&& chown -R www-data:www-data sites
+	&& chown -R www-data:www-data sites modules themes

--- a/8.2/fpm/Dockerfile
+++ b/8.2/fpm/Dockerfile
@@ -28,4 +28,4 @@ RUN curl -fSL "http://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar
 	&& echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c - \
 	&& tar -xz --strip-components=1 -f drupal.tar.gz \
 	&& rm drupal.tar.gz \
-	&& chown -R www-data:www-data sites
+	&& chown -R www-data:www-data sites modules themes


### PR DESCRIPTION
Drupal 8 uses a slightly different file structure, which is different from Drupal 7. In short, Drupal 8 puts downloaded modules and themes in /modules and /themes instead of /sites/all/modules and /sites/all/themes. Please see more detail at: http://drupal.stackexchange.com/a/84851/52907

Currently, users cannot install modules or themes via Drupal UI, because of the wrong folder ownership. This patch fixes it.

