### PR TITLE
use "https" for communications with "drupal.org"

### DIFF
--- a/7/apache/Dockerfile
+++ b/7/apache/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /var/www/html
 ENV DRUPAL_VERSION 7.50
 ENV DRUPAL_MD5 f23905b0248d76f0fc8316692cd64753
 
-RUN curl -fSL "http://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz \
+RUN curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz \
 	&& echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c - \
 	&& tar -xz --strip-components=1 -f drupal.tar.gz \
 	&& rm drupal.tar.gz \

--- a/7/fpm/Dockerfile
+++ b/7/fpm/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /var/www/html
 ENV DRUPAL_VERSION 7.50
 ENV DRUPAL_MD5 f23905b0248d76f0fc8316692cd64753
 
-RUN curl -fSL "http://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz \
+RUN curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz \
 	&& echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c - \
 	&& tar -xz --strip-components=1 -f drupal.tar.gz \
 	&& rm drupal.tar.gz \

--- a/8.1/apache/Dockerfile
+++ b/8.1/apache/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /var/www/html
 ENV DRUPAL_VERSION 8.1.8
 ENV DRUPAL_MD5 7c00b318590a22f2df7a18cf70df06dc
 
-RUN curl -fSL "http://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz \
+RUN curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz \
 	&& echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c - \
 	&& tar -xz --strip-components=1 -f drupal.tar.gz \
 	&& rm drupal.tar.gz \

--- a/8.1/fpm/Dockerfile
+++ b/8.1/fpm/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /var/www/html
 ENV DRUPAL_VERSION 8.1.8
 ENV DRUPAL_MD5 7c00b318590a22f2df7a18cf70df06dc
 
-RUN curl -fSL "http://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz \
+RUN curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz \
 	&& echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c - \
 	&& tar -xz --strip-components=1 -f drupal.tar.gz \
 	&& rm drupal.tar.gz \

--- a/8.2/apache/Dockerfile
+++ b/8.2/apache/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /var/www/html
 ENV DRUPAL_VERSION 8.2.0-beta3
 ENV DRUPAL_MD5 be99e1bc4050587b5cf414a9ab947356
 
-RUN curl -fSL "http://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz \
+RUN curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz \
 	&& echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c - \
 	&& tar -xz --strip-components=1 -f drupal.tar.gz \
 	&& rm drupal.tar.gz \

--- a/8.2/fpm/Dockerfile
+++ b/8.2/fpm/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /var/www/html
 ENV DRUPAL_VERSION 8.2.0-beta3
 ENV DRUPAL_MD5 be99e1bc4050587b5cf414a9ab947356
 
-RUN curl -fSL "http://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz \
+RUN curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz \
 	&& echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c - \
 	&& tar -xz --strip-components=1 -f drupal.tar.gz \
 	&& rm drupal.tar.gz \


### PR DESCRIPTION
Drupal itself also links to https downloads and there are even in the HSTS preload lists of some browsers.
So there is no drawback for also securing the downloads in Docker.