### PR TITLE
Use PHP 7.1 on Alpine and be consistent

### DIFF
--- a/8.3/fpm-alpine/Dockerfile
+++ b/8.3/fpm-alpine/Dockerfile
@@ -1,5 +1,5 @@
 # from https://www.drupal.org/requirements/php#drupalversions
-FROM php:7.0-fpm-alpine
+FROM php:7.1-fpm-alpine
 
 # install the PHP extensions we need
 # postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642


### PR DESCRIPTION
I just realized that Alpine was still using PHP7.0 on Drupal 8.3.x while other flavors already using PHP7.1. So, update this image to use PHP7.1. The official Drupal document suggests no problem with 7.1. https://www.drupal.org/docs/7/system-requirements/php and on the other hand, known and future  PHP7.1 compatibility issues with Core or with 3-rd parties will be worked on https://www.drupal.org/project/issues/search?text=&projects=&assigned=&submitted=&project_issue_followers=&status%5B%5D=Open&issue_tags_op=%3D&issue_tags=PHP+7.1