### PR TITLE
Update to D8.4.0 stable release.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: bash
 services: docker
 
 env:
-  - VERSION=8.4-rc VARIANT=apache
-  - VERSION=8.4-rc VARIANT=fpm
-  - VERSION=8.4-rc VARIANT=fpm-alpine
+  - VERSION=8.4 VARIANT=apache
+  - VERSION=8.4 VARIANT=fpm
+  - VERSION=8.4 VARIANT=fpm-alpine
   - VERSION=8.3 VARIANT=apache
   - VERSION=8.3 VARIANT=fpm
   - VERSION=8.3 VARIANT=fpm-alpine

--- a/8.4/apache/Dockerfile
+++ b/8.4/apache/Dockerfile
@@ -1,5 +1,7 @@
 # from https://www.drupal.org/requirements/php#drupalversions
-FROM php:7.1-fpm
+FROM php:7.1-apache
+
+RUN a2enmod rewrite
 
 # install the PHP extensions we need
 RUN set -ex \
@@ -34,8 +36,8 @@ RUN { \
 WORKDIR /var/www/html
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 8.4.0-rc2
-ENV DRUPAL_MD5 50730355dd1a82d988e484c2b4eff422
+ENV DRUPAL_VERSION 8.4.0
+ENV DRUPAL_MD5 074795a2f5fc0b599a7dcfb9d1fb03f5
 
 RUN curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz \
 	&& echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c - \

--- a/8.4/fpm-alpine/Dockerfile
+++ b/8.4/fpm-alpine/Dockerfile
@@ -38,8 +38,8 @@ RUN { \
 WORKDIR /var/www/html
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 8.4.0-rc2
-ENV DRUPAL_MD5 50730355dd1a82d988e484c2b4eff422
+ENV DRUPAL_VERSION 8.4.0
+ENV DRUPAL_MD5 074795a2f5fc0b599a7dcfb9d1fb03f5
 
 RUN curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz \
 	&& echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c - \

--- a/8.4/fpm/Dockerfile
+++ b/8.4/fpm/Dockerfile
@@ -1,7 +1,5 @@
 # from https://www.drupal.org/requirements/php#drupalversions
-FROM php:7.1-apache
-
-RUN a2enmod rewrite
+FROM php:7.1-fpm
 
 # install the PHP extensions we need
 RUN set -ex \
@@ -36,8 +34,8 @@ RUN { \
 WORKDIR /var/www/html
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 8.4.0-rc2
-ENV DRUPAL_MD5 50730355dd1a82d988e484c2b4eff422
+ENV DRUPAL_VERSION 8.4.0
+ENV DRUPAL_MD5 074795a2f5fc0b599a7dcfb9d1fb03f5
 
 RUN curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz \
 	&& echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c - \


### PR DESCRIPTION
The stable release has arrived: https://www.drupal.org/project/drupal/releases/8.4.0

This also means 8.3.x reached the end of life. I would wait until 8.4.1 release to remove 8.3.x