### PR TITLE
Fixed an accidental change when adding Drupal 8.5

### DIFF
--- a/8.4/apache/Dockerfile
+++ b/8.4/apache/Dockerfile
@@ -7,7 +7,7 @@ RUN a2enmod rewrite
 RUN set -ex \
 	&& buildDeps=' \
 		libjpeg62-turbo-dev \
-		libpng-dev \
+		libpng12-dev \
 		libpq-dev \
 	' \
 	&& apt-get update && apt-get install -y --no-install-recommends $buildDeps && rm -rf /var/lib/apt/lists/* \

--- a/8.4/fpm/Dockerfile
+++ b/8.4/fpm/Dockerfile
@@ -5,7 +5,7 @@ FROM php:7.1-fpm
 RUN set -ex \
 	&& buildDeps=' \
 		libjpeg62-turbo-dev \
-		libpng-dev \
+		libpng12-dev \
 		libpq-dev \
 	' \
 	&& apt-get update && apt-get install -y --no-install-recommends $buildDeps && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
We didn't update PHP version for Drupal 8.4.x branch in https://github.com/docker-library/drupal/commit/6721a34e18041e3e6bcb297aa5195bfddcf14071, but I didn't change the a dependency package name back.