### PR TITLE
Bump Drupal 7 to PHP 7.1; Fix update.sh so that it can scrape drupal releases again

### DIFF
--- a/7/apache/Dockerfile
+++ b/7/apache/Dockerfile
@@ -1,5 +1,5 @@
 # from https://www.drupal.org/docs/8/system-requirements/drupal-8-php-requirements
-FROM php:7.0-apache
+FROM php:7.1-apache
 
 # install the PHP extensions we need
 RUN set -ex; \
@@ -54,8 +54,8 @@ RUN { \
 WORKDIR /var/www/html
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 7.60
-ENV DRUPAL_MD5 ba14bf3ddc8e182adb49eb50ae117f3e
+ENV DRUPAL_VERSION 7.61
+ENV DRUPAL_MD5 94bc49170d98e0cfe59db487911ecb9d
 
 RUN curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz \
 	&& echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c - \

--- a/7/fpm-alpine/Dockerfile
+++ b/7/fpm-alpine/Dockerfile
@@ -1,5 +1,5 @@
 # from https://www.drupal.org/docs/8/system-requirements/drupal-8-php-requirements
-FROM php:7.0-fpm-alpine
+FROM php:7.1-fpm-alpine
 
 # install the PHP extensions we need
 # postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
@@ -43,8 +43,8 @@ RUN { \
 WORKDIR /var/www/html
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 7.60
-ENV DRUPAL_MD5 ba14bf3ddc8e182adb49eb50ae117f3e
+ENV DRUPAL_VERSION 7.61
+ENV DRUPAL_MD5 94bc49170d98e0cfe59db487911ecb9d
 
 RUN curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz \
 	&& echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c - \

--- a/7/fpm/Dockerfile
+++ b/7/fpm/Dockerfile
@@ -1,5 +1,5 @@
 # from https://www.drupal.org/docs/8/system-requirements/drupal-8-php-requirements
-FROM php:7.0-fpm
+FROM php:7.1-fpm
 
 # install the PHP extensions we need
 RUN set -ex; \
@@ -54,8 +54,8 @@ RUN { \
 WORKDIR /var/www/html
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 7.60
-ENV DRUPAL_MD5 ba14bf3ddc8e182adb49eb50ae117f3e
+ENV DRUPAL_VERSION 7.61
+ENV DRUPAL_MD5 94bc49170d98e0cfe59db487911ecb9d
 
 RUN curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz \
 	&& echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c - \

--- a/8.6/apache/Dockerfile
+++ b/8.6/apache/Dockerfile
@@ -54,8 +54,8 @@ RUN { \
 WORKDIR /var/www/html
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 8.6.2
-ENV DRUPAL_MD5 46a42d70047dafd4b05e3dd050cea887
+ENV DRUPAL_VERSION 8.6.3
+ENV DRUPAL_MD5 3a3b8e4326b493ed6c29188db40031ff
 
 RUN curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz \
 	&& echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c - \

--- a/8.6/fpm-alpine/Dockerfile
+++ b/8.6/fpm-alpine/Dockerfile
@@ -43,8 +43,8 @@ RUN { \
 WORKDIR /var/www/html
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 8.6.2
-ENV DRUPAL_MD5 46a42d70047dafd4b05e3dd050cea887
+ENV DRUPAL_VERSION 8.6.3
+ENV DRUPAL_MD5 3a3b8e4326b493ed6c29188db40031ff
 
 RUN curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz \
 	&& echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c - \

--- a/8.6/fpm/Dockerfile
+++ b/8.6/fpm/Dockerfile
@@ -54,8 +54,8 @@ RUN { \
 WORKDIR /var/www/html
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 8.6.2
-ENV DRUPAL_MD5 46a42d70047dafd4b05e3dd050cea887
+ENV DRUPAL_VERSION 8.6.3
+ENV DRUPAL_MD5 3a3b8e4326b493ed6c29188db40031ff
 
 RUN curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz \
 	&& echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c - \

--- a/update.sh
+++ b/update.sh
@@ -11,10 +11,10 @@ versions=( "${versions[@]%/}" )
 
 defaultPhpVersion='7.2'
 declare -A phpVersions=(
-	[7]='7.0'
+	[7]='7.1'
 )
 
-curl -fsSL 'https://www.drupal.org/node/3060/release' -o release
+curl -fsSL 'https://www.drupal.org/node/3060/release' -H 'authority: www.drupal.org' -o release
 trap 'rm -f release' EXIT
 
 travisEnv=


### PR DESCRIPTION
Also run update to bump versions and apply new PHP version.

The update.sh change is a temporary fix to get it to work more often; it needs to be updated again to use the "Releases" API described on https://www.drupal.org/drupalorg/docs/api, but it is only xml. :cry:

Fixes #136