### PR TITLE
Add Drupal 8.7 and remove 8.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ language: bash
 services: docker
 
 env:
+  - VERSION=8.7 VARIANT=apache
+  - VERSION=8.7 VARIANT=fpm
+  - VERSION=8.7 VARIANT=fpm-alpine
   - VERSION=8.6 VARIANT=apache
   - VERSION=8.6 VARIANT=fpm
   - VERSION=8.6 VARIANT=fpm-alpine
-  - VERSION=8.5 VARIANT=apache
-  - VERSION=8.5 VARIANT=fpm
-  - VERSION=8.5 VARIANT=fpm-alpine
   - VERSION=7 VARIANT=apache
   - VERSION=7 VARIANT=fpm
   - VERSION=7 VARIANT=fpm-alpine

--- a/7/apache/Dockerfile
+++ b/7/apache/Dockerfile
@@ -1,5 +1,5 @@
 # from https://www.drupal.org/docs/8/system-requirements/drupal-8-php-requirements
-FROM php:7.1-apache
+FROM php:7.2-apache
 
 # install the PHP extensions we need
 RUN set -ex; \
@@ -15,6 +15,7 @@ RUN set -ex; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \

--- a/7/fpm-alpine/Dockerfile
+++ b/7/fpm-alpine/Dockerfile
@@ -1,5 +1,5 @@
 # from https://www.drupal.org/docs/8/system-requirements/drupal-8-php-requirements
-FROM php:7.1-fpm-alpine
+FROM php:7.2-fpm-alpine
 
 # install the PHP extensions we need
 # postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
@@ -9,6 +9,7 @@ RUN set -ex \
 		freetype-dev \
 		libjpeg-turbo-dev \
 		libpng-dev \
+		libzip-dev \
 		postgresql-dev \
 	&& docker-php-ext-configure gd \
 		--with-freetype-dir=/usr/include/ \

--- a/7/fpm/Dockerfile
+++ b/7/fpm/Dockerfile
@@ -1,5 +1,5 @@
 # from https://www.drupal.org/docs/8/system-requirements/drupal-8-php-requirements
-FROM php:7.1-fpm
+FROM php:7.2-fpm
 
 # install the PHP extensions we need
 RUN set -ex; \
@@ -15,6 +15,7 @@ RUN set -ex; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \

--- a/8.6/apache/Dockerfile
+++ b/8.6/apache/Dockerfile
@@ -1,5 +1,5 @@
 # from https://www.drupal.org/docs/8/system-requirements/drupal-8-php-requirements
-FROM php:7.2-apache
+FROM php:7.3-apache
 
 # install the PHP extensions we need
 RUN set -ex; \
@@ -15,6 +15,7 @@ RUN set -ex; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \

--- a/8.6/fpm-alpine/Dockerfile
+++ b/8.6/fpm-alpine/Dockerfile
@@ -1,5 +1,5 @@
 # from https://www.drupal.org/docs/8/system-requirements/drupal-8-php-requirements
-FROM php:7.2-fpm-alpine
+FROM php:7.3-fpm-alpine
 
 # install the PHP extensions we need
 # postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
@@ -9,6 +9,7 @@ RUN set -ex \
 		freetype-dev \
 		libjpeg-turbo-dev \
 		libpng-dev \
+		libzip-dev \
 		postgresql-dev \
 	&& docker-php-ext-configure gd \
 		--with-freetype-dir=/usr/include/ \

--- a/8.6/fpm/Dockerfile
+++ b/8.6/fpm/Dockerfile
@@ -1,5 +1,5 @@
 # from https://www.drupal.org/docs/8/system-requirements/drupal-8-php-requirements
-FROM php:7.2-fpm
+FROM php:7.3-fpm
 
 # install the PHP extensions we need
 RUN set -ex; \
@@ -15,6 +15,7 @@ RUN set -ex; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \

--- a/8.7/apache/Dockerfile
+++ b/8.7/apache/Dockerfile
@@ -1,5 +1,5 @@
 # from https://www.drupal.org/docs/8/system-requirements/drupal-8-php-requirements
-FROM php:7.2-apache
+FROM php:7.3-apache
 
 # install the PHP extensions we need
 RUN set -ex; \
@@ -15,6 +15,7 @@ RUN set -ex; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
@@ -54,8 +55,8 @@ RUN { \
 WORKDIR /var/www/html
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 8.5.15
-ENV DRUPAL_MD5 7a4ba499132c834e5d33bccae5ac1430
+ENV DRUPAL_VERSION 8.7.1
+ENV DRUPAL_MD5 2cf2a1c93ea785c6ff91d29aebef2697
 
 RUN curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz \
 	&& echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c - \

--- a/8.7/fpm-alpine/Dockerfile
+++ b/8.7/fpm-alpine/Dockerfile
@@ -1,5 +1,5 @@
 # from https://www.drupal.org/docs/8/system-requirements/drupal-8-php-requirements
-FROM php:7.2-fpm-alpine
+FROM php:7.3-fpm-alpine
 
 # install the PHP extensions we need
 # postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
@@ -9,6 +9,7 @@ RUN set -ex \
 		freetype-dev \
 		libjpeg-turbo-dev \
 		libpng-dev \
+		libzip-dev \
 		postgresql-dev \
 	&& docker-php-ext-configure gd \
 		--with-freetype-dir=/usr/include/ \
@@ -43,8 +44,8 @@ RUN { \
 WORKDIR /var/www/html
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 8.5.15
-ENV DRUPAL_MD5 7a4ba499132c834e5d33bccae5ac1430
+ENV DRUPAL_VERSION 8.7.1
+ENV DRUPAL_MD5 2cf2a1c93ea785c6ff91d29aebef2697
 
 RUN curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz \
 	&& echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c - \

--- a/8.7/fpm/Dockerfile
+++ b/8.7/fpm/Dockerfile
@@ -1,5 +1,5 @@
 # from https://www.drupal.org/docs/8/system-requirements/drupal-8-php-requirements
-FROM php:7.2-fpm
+FROM php:7.3-fpm
 
 # install the PHP extensions we need
 RUN set -ex; \
@@ -15,6 +15,7 @@ RUN set -ex; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
@@ -54,8 +55,8 @@ RUN { \
 WORKDIR /var/www/html
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 8.5.15
-ENV DRUPAL_MD5 7a4ba499132c834e5d33bccae5ac1430
+ENV DRUPAL_VERSION 8.7.1
+ENV DRUPAL_MD5 2cf2a1c93ea785c6ff91d29aebef2697
 
 RUN curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz \
 	&& echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c - \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -9,6 +9,7 @@ RUN set -ex \
 		freetype-dev \
 		libjpeg-turbo-dev \
 		libpng-dev \
+		libzip-dev \
 		postgresql-dev \
 	&& docker-php-ext-configure gd \
 		--with-freetype-dir=/usr/include/ \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -15,6 +15,7 @@ RUN set -ex; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -2,8 +2,8 @@
 set -eu
 
 declare -A aliases=(
-	[8.6]='8 latest'
-	[8.7-rc]='rc'
+	[8.7]='8 latest'
+	[8.8-rc]='rc'
 )
 
 self="$(basename "$BASH_SOURCE")"

--- a/update.sh
+++ b/update.sh
@@ -9,9 +9,9 @@ if [ ${#versions[@]} -eq 0 ]; then
 fi
 versions=( "${versions[@]%/}" )
 
-defaultPhpVersion='7.2'
+defaultPhpVersion='7.3'
 declare -A phpVersions=(
-	[7]='7.1'
+	[7]='7.2'
 )
 
 travisEnv=


### PR DESCRIPTION
8.7 stable was released, and 8.5 reached EOL on May 1st, 2019, see https://www.drupal.org/core/release-cycle-overview#current-development-cycle

I also upgraded the PHP version to 7.3 for Drupal 8.7, https://www.drupal.org/docs/8/system-requirements/php-requirements , but kept 7.2 for Drupal 8.6