### PR TITLE
Add Drupal 8.8 and remove 8.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ language: bash
 services: docker
 
 env:
+  - VERSION=8.8 VARIANT=apache
+  - VERSION=8.8 VARIANT=fpm
+  - VERSION=8.8 VARIANT=fpm-alpine
   - VERSION=8.7 VARIANT=apache
   - VERSION=8.7 VARIANT=fpm
   - VERSION=8.7 VARIANT=fpm-alpine
-  - VERSION=8.6 VARIANT=apache
-  - VERSION=8.6 VARIANT=fpm
-  - VERSION=8.6 VARIANT=fpm-alpine
   - VERSION=7 VARIANT=apache
   - VERSION=7 VARIANT=fpm
   - VERSION=7 VARIANT=fpm-alpine

--- a/8.8/apache/Dockerfile
+++ b/8.8/apache/Dockerfile
@@ -1,5 +1,5 @@
 # from https://www.drupal.org/docs/8/system-requirements/drupal-8-php-requirements
-FROM php:7.3-fpm-stretch
+FROM php:7.3-apache-stretch
 # TODO switch to buster once https://github.com/docker-library/php/issues/865 is resolved in a clean way (either in the PHP image or in PHP itself)
 
 # install the PHP extensions we need
@@ -61,8 +61,8 @@ RUN { \
 WORKDIR /var/www/html
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 8.6.18
-ENV DRUPAL_MD5 6bef7039de8b5cdd28e7971529138e30
+ENV DRUPAL_VERSION 8.8.0
+ENV DRUPAL_MD5 e51156b53a154109c0a048eb8793b8f1
 
 RUN set -eux; \
 	curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz; \

--- a/8.8/fpm-alpine/Dockerfile
+++ b/8.8/fpm-alpine/Dockerfile
@@ -50,8 +50,8 @@ RUN { \
 WORKDIR /var/www/html
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 8.6.18
-ENV DRUPAL_MD5 6bef7039de8b5cdd28e7971529138e30
+ENV DRUPAL_VERSION 8.8.0
+ENV DRUPAL_MD5 e51156b53a154109c0a048eb8793b8f1
 
 RUN set -eux; \
 	curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz; \

--- a/8.8/fpm/Dockerfile
+++ b/8.8/fpm/Dockerfile
@@ -1,5 +1,5 @@
 # from https://www.drupal.org/docs/8/system-requirements/drupal-8-php-requirements
-FROM php:7.3-apache-stretch
+FROM php:7.3-fpm-stretch
 # TODO switch to buster once https://github.com/docker-library/php/issues/865 is resolved in a clean way (either in the PHP image or in PHP itself)
 
 # install the PHP extensions we need
@@ -61,8 +61,8 @@ RUN { \
 WORKDIR /var/www/html
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 8.6.18
-ENV DRUPAL_MD5 6bef7039de8b5cdd28e7971529138e30
+ENV DRUPAL_VERSION 8.8.0
+ENV DRUPAL_MD5 e51156b53a154109c0a048eb8793b8f1
 
 RUN set -eux; \
 	curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz; \

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -2,8 +2,8 @@
 set -eu
 
 declare -A aliases=(
-	[8.7]='8 latest'
-	[8.8-rc]='rc'
+	[8.8]='8 latest'
+	[8.9-rc]='rc'
 )
 
 self="$(basename "$BASH_SOURCE")"


### PR DESCRIPTION
Like the situation in https://github.com/docker-library/drupal/pull/150#issue-275965410 , 8.8 is released on Dec. 4, 2019, and meanwhile, 8.6.x is reaching it's  EOL.

So it would be nice if we make changes in time.