### PR TITLE
fix: issue 3094738

### DIFF
--- a/8.7/apache/Dockerfile
+++ b/8.7/apache/Dockerfile
@@ -64,11 +64,13 @@ WORKDIR /var/www/html
 ENV DRUPAL_VERSION 8.7.11
 ENV DRUPAL_MD5 bcf01576c060dfb7de0ec1f7125f7bbe
 
+# sed to fix https://www.drupal.org/project/drupal/issues/3094738
 RUN set -eux; \
 	curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz; \
 	echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c -; \
 	tar -xz --strip-components=1 -f drupal.tar.gz; \
 	rm drupal.tar.gz; \
+	sed -i "s/OR pg_attrdef.adsrc LIKE 'nextval%')/OR pg_get_expr(pg_attrdef.adbin, pg_attribute.attrelid) LIKE 'nextval%')/g" ./core/lib/Drupal/Core/Database/Driver/pgsql/Schema.php; \
 	chown -R www-data:www-data sites modules themes
 
 # vim:set ft=dockerfile:

--- a/8.7/fpm-alpine/Dockerfile
+++ b/8.7/fpm-alpine/Dockerfile
@@ -53,11 +53,13 @@ WORKDIR /var/www/html
 ENV DRUPAL_VERSION 8.7.11
 ENV DRUPAL_MD5 bcf01576c060dfb7de0ec1f7125f7bbe
 
+# sed to fix https://www.drupal.org/project/drupal/issues/3094738
 RUN set -eux; \
 	curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz; \
 	echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c -; \
 	tar -xz --strip-components=1 -f drupal.tar.gz; \
 	rm drupal.tar.gz; \
+	sed -i "s/OR pg_attrdef.adsrc LIKE 'nextval%')/OR pg_get_expr(pg_attrdef.adbin, pg_attribute.attrelid) LIKE 'nextval%')/g" ./core/lib/Drupal/Core/Database/Driver/pgsql/Schema.php; \
 	chown -R www-data:www-data sites modules themes
 
 # vim:set ft=dockerfile:

--- a/8.7/fpm/Dockerfile
+++ b/8.7/fpm/Dockerfile
@@ -64,11 +64,13 @@ WORKDIR /var/www/html
 ENV DRUPAL_VERSION 8.7.11
 ENV DRUPAL_MD5 bcf01576c060dfb7de0ec1f7125f7bbe
 
+# sed to fix https://www.drupal.org/project/drupal/issues/3094738
 RUN set -eux; \
 	curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz; \
 	echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c -; \
 	tar -xz --strip-components=1 -f drupal.tar.gz; \
 	rm drupal.tar.gz; \
+	sed -i "s/OR pg_attrdef.adsrc LIKE 'nextval%')/OR pg_get_expr(pg_attrdef.adbin, pg_attribute.attrelid) LIKE 'nextval%')/g" ./core/lib/Drupal/Core/Database/Driver/pgsql/Schema.php; \
 	chown -R www-data:www-data sites modules themes
 
 # vim:set ft=dockerfile:

--- a/8.8/apache/Dockerfile
+++ b/8.8/apache/Dockerfile
@@ -64,11 +64,13 @@ WORKDIR /var/www/html
 ENV DRUPAL_VERSION 8.8.1
 ENV DRUPAL_MD5 0e0af2652e6ad4da27c0f7bf35c5e1e1
 
+# sed to fix https://www.drupal.org/project/drupal/issues/3094738
 RUN set -eux; \
 	curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz; \
 	echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c -; \
 	tar -xz --strip-components=1 -f drupal.tar.gz; \
 	rm drupal.tar.gz; \
+	sed -i "s/OR pg_attrdef.adsrc LIKE 'nextval%')/OR pg_get_expr(pg_attrdef.adbin, pg_attribute.attrelid) LIKE 'nextval%')/g" ./core/lib/Drupal/Core/Database/Driver/pgsql/Schema.php; \
 	chown -R www-data:www-data sites modules themes
 
 # vim:set ft=dockerfile:

--- a/8.8/fpm-alpine/Dockerfile
+++ b/8.8/fpm-alpine/Dockerfile
@@ -53,11 +53,13 @@ WORKDIR /var/www/html
 ENV DRUPAL_VERSION 8.8.1
 ENV DRUPAL_MD5 0e0af2652e6ad4da27c0f7bf35c5e1e1
 
+# sed to fix https://www.drupal.org/project/drupal/issues/3094738
 RUN set -eux; \
 	curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz; \
 	echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c -; \
 	tar -xz --strip-components=1 -f drupal.tar.gz; \
 	rm drupal.tar.gz; \
+	sed -i "s/OR pg_attrdef.adsrc LIKE 'nextval%')/OR pg_get_expr(pg_attrdef.adbin, pg_attribute.attrelid) LIKE 'nextval%')/g" ./core/lib/Drupal/Core/Database/Driver/pgsql/Schema.php; \
 	chown -R www-data:www-data sites modules themes
 
 # vim:set ft=dockerfile:

--- a/8.8/fpm/Dockerfile
+++ b/8.8/fpm/Dockerfile
@@ -64,11 +64,13 @@ WORKDIR /var/www/html
 ENV DRUPAL_VERSION 8.8.1
 ENV DRUPAL_MD5 0e0af2652e6ad4da27c0f7bf35c5e1e1
 
+# sed to fix https://www.drupal.org/project/drupal/issues/3094738
 RUN set -eux; \
 	curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz; \
 	echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c -; \
 	tar -xz --strip-components=1 -f drupal.tar.gz; \
 	rm drupal.tar.gz; \
+	sed -i "s/OR pg_attrdef.adsrc LIKE 'nextval%')/OR pg_get_expr(pg_attrdef.adbin, pg_attribute.attrelid) LIKE 'nextval%')/g" ./core/lib/Drupal/Core/Database/Driver/pgsql/Schema.php; \
 	chown -R www-data:www-data sites modules themes
 
 # vim:set ft=dockerfile:


### PR DESCRIPTION
The addition of this `sed` implements the patch proposed in [this discussion](https://www.drupal.org/project/drupal/issues/3094738). The bug typically occurred using Postgresql >12.0 with Drupal 8.7 | 8.8 like in the following *docker-compose*:

```yaml
  drupal:
    image: drupal:8.8.1-fpm-alpine

  postgres:
    image: postgres:12.1-alpine
```

[**original bug**]
```
Drupal\Core\Database\DatabaseExceptionWrapper: SQLSTATE[42703]: Undefined column: 7 ERROR: column pg_attrdef.adsrc does not exist LINE 8: OR pg_attrdef.adsrc::text LIKE 'nextval%') ^: SELECT pg_attribute.attname AS column_name, format_type(pg_attribute.atttypid, pg_attribute.atttypmod) AS data_type, pg_get_expr(pg_attrdef.adbin, pg_attribute.attrelid) AS column_default FROM pg_attribute LEFT JOIN pg_attrdef ON pg_attrdef.adrelid = pg_attribute.attrelid AND pg_attrdef.adnum = pg_attribute.attnum WHERE pg_attribute.attnum > 0 AND NOT pg_attribute.attisdropped AND pg_attribute.attrelid = :key::regclass AND (format_type(pg_attribute.atttypid, pg_attribute.atttypmod) = 'bytea' OR pg_attrdef.adsrc LIKE 'nextval%'); Array ( [:key] => public.cache_bootstrap ) in Drupal\Core\Extension\ModuleHandler->getHookInfo() (line 297 of /var/www/html/drupal/app/core/lib/Drupal/Core/Extension/ModuleHandler.php).
```