### PR TITLE
Refactor update.sh to the new update status information

### DIFF
--- a/7/apache/Dockerfile
+++ b/7/apache/Dockerfile
@@ -1,6 +1,5 @@
 # from https://www.drupal.org/docs/8/system-requirements/drupal-8-php-requirements
 FROM php:7.4-apache-buster
-# TODO switch to buster once https://github.com/docker-library/php/issues/865 is resolved in a clean way (either in the PHP image or in PHP itself)
 
 # install the PHP extensions we need
 RUN set -eux; \
@@ -64,7 +63,7 @@ ENV DRUPAL_VERSION 7.71
 ENV DRUPAL_MD5 559227e04b8fa86e0374dbed6a228109
 
 RUN set -eux; \
-	curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz; \
+	curl -fSL "https://ftp.drupal.org/files/projects/drupal-7.71.tar.gz" -o drupal.tar.gz; \
 	echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c -; \
 	tar -xz --strip-components=1 -f drupal.tar.gz; \
 	rm drupal.tar.gz; \

--- a/7/fpm-alpine/Dockerfile
+++ b/7/fpm-alpine/Dockerfile
@@ -53,7 +53,7 @@ ENV DRUPAL_VERSION 7.71
 ENV DRUPAL_MD5 559227e04b8fa86e0374dbed6a228109
 
 RUN set -eux; \
-	curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz; \
+	curl -fSL "https://ftp.drupal.org/files/projects/drupal-7.71.tar.gz" -o drupal.tar.gz; \
 	echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c -; \
 	tar -xz --strip-components=1 -f drupal.tar.gz; \
 	rm drupal.tar.gz; \

--- a/7/fpm/Dockerfile
+++ b/7/fpm/Dockerfile
@@ -1,6 +1,5 @@
 # from https://www.drupal.org/docs/8/system-requirements/drupal-8-php-requirements
 FROM php:7.4-fpm-buster
-# TODO switch to buster once https://github.com/docker-library/php/issues/865 is resolved in a clean way (either in the PHP image or in PHP itself)
 
 # install the PHP extensions we need
 RUN set -eux; \
@@ -64,7 +63,7 @@ ENV DRUPAL_VERSION 7.71
 ENV DRUPAL_MD5 559227e04b8fa86e0374dbed6a228109
 
 RUN set -eux; \
-	curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz; \
+	curl -fSL "https://ftp.drupal.org/files/projects/drupal-7.71.tar.gz" -o drupal.tar.gz; \
 	echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c -; \
 	tar -xz --strip-components=1 -f drupal.tar.gz; \
 	rm drupal.tar.gz; \

--- a/8.8/apache/Dockerfile
+++ b/8.8/apache/Dockerfile
@@ -1,6 +1,5 @@
 # from https://www.drupal.org/docs/8/system-requirements/drupal-8-php-requirements
 FROM php:7.4-apache-buster
-# TODO switch to buster once https://github.com/docker-library/php/issues/865 is resolved in a clean way (either in the PHP image or in PHP itself)
 
 # install the PHP extensions we need
 RUN set -eux; \
@@ -64,7 +63,7 @@ ENV DRUPAL_VERSION 8.8.7
 ENV DRUPAL_MD5 cf073efecded37ef41122fb63b9721a2
 
 RUN set -eux; \
-	curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz; \
+	curl -fSL "https://ftp.drupal.org/files/projects/drupal-8.8.7.tar.gz" -o drupal.tar.gz; \
 	echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c -; \
 	tar -xz --strip-components=1 -f drupal.tar.gz; \
 	rm drupal.tar.gz; \

--- a/8.8/fpm-alpine/Dockerfile
+++ b/8.8/fpm-alpine/Dockerfile
@@ -53,7 +53,7 @@ ENV DRUPAL_VERSION 8.8.7
 ENV DRUPAL_MD5 cf073efecded37ef41122fb63b9721a2
 
 RUN set -eux; \
-	curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz; \
+	curl -fSL "https://ftp.drupal.org/files/projects/drupal-8.8.7.tar.gz" -o drupal.tar.gz; \
 	echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c -; \
 	tar -xz --strip-components=1 -f drupal.tar.gz; \
 	rm drupal.tar.gz; \

--- a/8.8/fpm/Dockerfile
+++ b/8.8/fpm/Dockerfile
@@ -1,6 +1,5 @@
 # from https://www.drupal.org/docs/8/system-requirements/drupal-8-php-requirements
 FROM php:7.4-fpm-buster
-# TODO switch to buster once https://github.com/docker-library/php/issues/865 is resolved in a clean way (either in the PHP image or in PHP itself)
 
 # install the PHP extensions we need
 RUN set -eux; \
@@ -64,7 +63,7 @@ ENV DRUPAL_VERSION 8.8.7
 ENV DRUPAL_MD5 cf073efecded37ef41122fb63b9721a2
 
 RUN set -eux; \
-	curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz; \
+	curl -fSL "https://ftp.drupal.org/files/projects/drupal-8.8.7.tar.gz" -o drupal.tar.gz; \
 	echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c -; \
 	tar -xz --strip-components=1 -f drupal.tar.gz; \
 	rm drupal.tar.gz; \

--- a/8.9/fpm-alpine/Dockerfile
+++ b/8.9/fpm-alpine/Dockerfile
@@ -53,7 +53,7 @@ ENV DRUPAL_VERSION 8.9.0
 ENV DRUPAL_MD5 3f57e9e8a7c2fe9c499712d5d254f55b
 
 RUN set -eux; \
-	curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz; \
+	curl -fSL "https://ftp.drupal.org/files/projects/drupal-8.9.0.tar.gz" -o drupal.tar.gz; \
 	echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c -; \
 	tar -xz --strip-components=1 -f drupal.tar.gz; \
 	rm drupal.tar.gz; \

--- a/8.9/fpm/Dockerfile
+++ b/8.9/fpm/Dockerfile
@@ -1,6 +1,5 @@
 # from https://www.drupal.org/docs/8/system-requirements/drupal-8-php-requirements
 FROM php:7.4-fpm-buster
-# TODO switch to buster once https://github.com/docker-library/php/issues/865 is resolved in a clean way (either in the PHP image or in PHP itself)
 
 # install the PHP extensions we need
 RUN set -eux; \
@@ -64,7 +63,7 @@ ENV DRUPAL_VERSION 8.9.0
 ENV DRUPAL_MD5 3f57e9e8a7c2fe9c499712d5d254f55b
 
 RUN set -eux; \
-	curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz; \
+	curl -fSL "https://ftp.drupal.org/files/projects/drupal-8.9.0.tar.gz" -o drupal.tar.gz; \
 	echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c -; \
 	tar -xz --strip-components=1 -f drupal.tar.gz; \
 	rm drupal.tar.gz; \

--- a/9.0/apache/Dockerfile
+++ b/9.0/apache/Dockerfile
@@ -59,11 +59,11 @@ RUN { \
 WORKDIR /var/www/html
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 8.9.0
-ENV DRUPAL_MD5 3f57e9e8a7c2fe9c499712d5d254f55b
+ENV DRUPAL_VERSION 9.0.0
+ENV DRUPAL_MD5 50885d5284546864c4c02f621472fc94
 
 RUN set -eux; \
-	curl -fSL "https://ftp.drupal.org/files/projects/drupal-8.9.0.tar.gz" -o drupal.tar.gz; \
+	curl -fSL "https://ftp.drupal.org/files/projects/drupal-9.0.0.tar.gz" -o drupal.tar.gz; \
 	echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c -; \
 	tar -xz --strip-components=1 -f drupal.tar.gz; \
 	rm drupal.tar.gz; \

--- a/9.0/fpm-alpine/Dockerfile
+++ b/9.0/fpm-alpine/Dockerfile
@@ -1,27 +1,22 @@
 # from https://www.drupal.org/docs/8/system-requirements/drupal-8-php-requirements
-FROM php:7.4-apache-buster
+FROM php:7.4-fpm-alpine
 
 # install the PHP extensions we need
+# postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
 RUN set -eux; \
 	\
-	if command -v a2enmod; then \
-		a2enmod rewrite; \
-	fi; \
-	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	\
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		libfreetype6-dev \
-		libjpeg-dev \
+	apk add --no-cache --virtual .build-deps \
+		coreutils \
+		freetype-dev \
+		libjpeg-turbo-dev \
 		libpng-dev \
-		libpq-dev \
 		libzip-dev \
+		postgresql-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
-		--with-jpeg=/usr \
+		--with-jpeg=/usr/include \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \
@@ -32,19 +27,14 @@ RUN set -eux; \
 		zip \
 	; \
 	\
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
-	apt-mark auto '.*' > /dev/null; \
-	apt-mark manual $savedAptMark; \
-	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
-		| awk '/=>/ { print $3 }' \
-		| sort -u \
-		| xargs -r dpkg-query -S \
-		| cut -d: -f1 \
-		| sort -u \
-		| xargs -rt apt-mark manual; \
-	\
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*
+	runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)"; \
+	apk add --virtual .drupal-phpexts-rundeps $runDeps; \
+	apk del .build-deps
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php
@@ -59,11 +49,11 @@ RUN { \
 WORKDIR /var/www/html
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 8.9.0
-ENV DRUPAL_MD5 3f57e9e8a7c2fe9c499712d5d254f55b
+ENV DRUPAL_VERSION 9.0.0
+ENV DRUPAL_MD5 50885d5284546864c4c02f621472fc94
 
 RUN set -eux; \
-	curl -fSL "https://ftp.drupal.org/files/projects/drupal-8.9.0.tar.gz" -o drupal.tar.gz; \
+	curl -fSL "https://ftp.drupal.org/files/projects/drupal-9.0.0.tar.gz" -o drupal.tar.gz; \
 	echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c -; \
 	tar -xz --strip-components=1 -f drupal.tar.gz; \
 	rm drupal.tar.gz; \

--- a/9.0/fpm/Dockerfile
+++ b/9.0/fpm/Dockerfile
@@ -1,5 +1,5 @@
 # from https://www.drupal.org/docs/8/system-requirements/drupal-8-php-requirements
-FROM php:7.4-apache-buster
+FROM php:7.4-fpm-buster
 
 # install the PHP extensions we need
 RUN set -eux; \
@@ -59,11 +59,11 @@ RUN { \
 WORKDIR /var/www/html
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 8.9.0
-ENV DRUPAL_MD5 3f57e9e8a7c2fe9c499712d5d254f55b
+ENV DRUPAL_VERSION 9.0.0
+ENV DRUPAL_MD5 50885d5284546864c4c02f621472fc94
 
 RUN set -eux; \
-	curl -fSL "https://ftp.drupal.org/files/projects/drupal-8.9.0.tar.gz" -o drupal.tar.gz; \
+	curl -fSL "https://ftp.drupal.org/files/projects/drupal-9.0.0.tar.gz" -o drupal.tar.gz; \
 	echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c -; \
 	tar -xz --strip-components=1 -f drupal.tar.gz; \
 	rm drupal.tar.gz; \

--- a/9.1/apache/Dockerfile
+++ b/9.1/apache/Dockerfile
@@ -59,11 +59,11 @@ RUN { \
 WORKDIR /var/www/html
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 8.9.0
-ENV DRUPAL_MD5 3f57e9e8a7c2fe9c499712d5d254f55b
+ENV DRUPAL_VERSION 9.1.x-dev
+ENV DRUPAL_MD5 5dfd13d037956bf2149ef1446ee50a23
 
 RUN set -eux; \
-	curl -fSL "https://ftp.drupal.org/files/projects/drupal-8.9.0.tar.gz" -o drupal.tar.gz; \
+	curl -fSL "https://ftp.drupal.org/files/projects/drupal-9.1.x-dev.tar.gz" -o drupal.tar.gz; \
 	echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c -; \
 	tar -xz --strip-components=1 -f drupal.tar.gz; \
 	rm drupal.tar.gz; \

--- a/9.1/fpm-alpine/Dockerfile
+++ b/9.1/fpm-alpine/Dockerfile
@@ -1,27 +1,22 @@
 # from https://www.drupal.org/docs/8/system-requirements/drupal-8-php-requirements
-FROM php:7.4-apache-buster
+FROM php:7.4-fpm-alpine
 
 # install the PHP extensions we need
+# postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
 RUN set -eux; \
 	\
-	if command -v a2enmod; then \
-		a2enmod rewrite; \
-	fi; \
-	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	\
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		libfreetype6-dev \
-		libjpeg-dev \
+	apk add --no-cache --virtual .build-deps \
+		coreutils \
+		freetype-dev \
+		libjpeg-turbo-dev \
 		libpng-dev \
-		libpq-dev \
 		libzip-dev \
+		postgresql-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
-		--with-jpeg=/usr \
+		--with-jpeg=/usr/include \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \
@@ -32,19 +27,14 @@ RUN set -eux; \
 		zip \
 	; \
 	\
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
-	apt-mark auto '.*' > /dev/null; \
-	apt-mark manual $savedAptMark; \
-	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
-		| awk '/=>/ { print $3 }' \
-		| sort -u \
-		| xargs -r dpkg-query -S \
-		| cut -d: -f1 \
-		| sort -u \
-		| xargs -rt apt-mark manual; \
-	\
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*
+	runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)"; \
+	apk add --virtual .drupal-phpexts-rundeps $runDeps; \
+	apk del .build-deps
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php
@@ -59,11 +49,11 @@ RUN { \
 WORKDIR /var/www/html
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 8.9.0
-ENV DRUPAL_MD5 3f57e9e8a7c2fe9c499712d5d254f55b
+ENV DRUPAL_VERSION 9.1.x-dev
+ENV DRUPAL_MD5 5dfd13d037956bf2149ef1446ee50a23
 
 RUN set -eux; \
-	curl -fSL "https://ftp.drupal.org/files/projects/drupal-8.9.0.tar.gz" -o drupal.tar.gz; \
+	curl -fSL "https://ftp.drupal.org/files/projects/drupal-9.1.x-dev.tar.gz" -o drupal.tar.gz; \
 	echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c -; \
 	tar -xz --strip-components=1 -f drupal.tar.gz; \
 	rm drupal.tar.gz; \

--- a/9.1/fpm/Dockerfile
+++ b/9.1/fpm/Dockerfile
@@ -1,5 +1,5 @@
 # from https://www.drupal.org/docs/8/system-requirements/drupal-8-php-requirements
-FROM php:7.4-apache-buster
+FROM php:7.4-fpm-buster
 
 # install the PHP extensions we need
 RUN set -eux; \
@@ -59,11 +59,11 @@ RUN { \
 WORKDIR /var/www/html
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 8.9.0
-ENV DRUPAL_MD5 3f57e9e8a7c2fe9c499712d5d254f55b
+ENV DRUPAL_VERSION 9.1.x-dev
+ENV DRUPAL_MD5 5dfd13d037956bf2149ef1446ee50a23
 
 RUN set -eux; \
-	curl -fSL "https://ftp.drupal.org/files/projects/drupal-8.9.0.tar.gz" -o drupal.tar.gz; \
+	curl -fSL "https://ftp.drupal.org/files/projects/drupal-9.1.x-dev.tar.gz" -o drupal.tar.gz; \
 	echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c -; \
 	tar -xz --strip-components=1 -f drupal.tar.gz; \
 	rm drupal.tar.gz; \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -53,7 +53,7 @@ ENV DRUPAL_VERSION %%VERSION%%
 ENV DRUPAL_MD5 %%MD5%%
 
 RUN set -eux; \
-	curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz; \
+	curl -fSL "%%URL%%" -o drupal.tar.gz; \
 	echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c -; \
 	tar -xz --strip-components=1 -f drupal.tar.gz; \
 	rm drupal.tar.gz; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -1,6 +1,5 @@
 # from https://www.drupal.org/docs/8/system-requirements/drupal-8-php-requirements
 FROM php:%%PHP_VERSION%%-%%VARIANT%%-buster
-# TODO switch to buster once https://github.com/docker-library/php/issues/865 is resolved in a clean way (either in the PHP image or in PHP itself)
 
 # install the PHP extensions we need
 RUN set -eux; \
@@ -64,7 +63,7 @@ ENV DRUPAL_VERSION %%VERSION%%
 ENV DRUPAL_MD5 %%MD5%%
 
 RUN set -eux; \
-	curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz; \
+	curl -fSL "%%URL%%" -o drupal.tar.gz; \
 	echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c -; \
 	tar -xz --strip-components=1 -f drupal.tar.gz; \
 	rm drupal.tar.gz; \

--- a/update.sh
+++ b/update.sh
@@ -6,6 +6,7 @@ declare -A phpVersions=(
 	# https://www.drupal.org/docs/7/system-requirements/php-requirements#php_required
 	#[7]='7.2'
 )
+docker pull php:cli 
 docker run -ti -v $PWD/xml.php:/xml.php php:cli php /xml.php > /tmp/versions
 IFS=" "
 while read version fullVersion url md5

--- a/xml.php
+++ b/xml.php
@@ -1,0 +1,56 @@
+<?php
+
+$doc = new SimpleXMLElement(file_get_contents('https://updates.drupal.org/release-history/drupal/current'));
+$versions = getSupportedVersions($doc);
+
+$doc7 = new SimpleXMLElement(file_get_contents('https://updates.drupal.org/release-history/drupal/7.x'));
+$versions7 = ['7.'];
+$informations = array_merge(getVersionInformations($doc7, $versions7), getVersionInformations($doc, $versions));
+
+foreach ($informations as $information) {
+    print "$information\n";
+}
+
+
+function getSupportedVersions(SimpleXMLElement $doc)
+{
+    return explode(',', $doc->supported_branches[0]);
+    return array_map(function ($value) {
+        return substr($value, 0, -1);
+    }, $versions);
+}
+
+function getVersionInformations(SimpleXMLElement $doc, $versions) {
+    $informations = [];
+    foreach($doc->releases[0] as $release)
+    {
+        $specific_version = (string)$release->version;
+        $founded_versions = array_filter($versions, 
+        function ($version) use ($specific_version) {
+            return strpos($specific_version, $version) === 0;
+        });
+        if (sizeof($founded_versions) !== 1) {
+            continue;
+        }
+        $founded_version = array_shift($founded_versions);
+        if (array_key_exists($founded_version, $informations)) {
+            continue;
+        }
+        $file = [];
+        foreach($release->files->file as $archive) {
+            if ((string)$archive->archive_type === 'tar.gz') {
+                $file['url'] = (string)$archive->url;
+                $file['md5'] = (string)$archive->md5;
+            }
+        }
+        if (sizeof($file) === 0) {
+            continue;
+        }
+        $informations[$founded_version] = 
+            substr($founded_version, 0, -1) . ' ' .
+            $specific_version . ' ' . 
+            $file['url'] . ' ' .
+            $file['md5'];
+    }    
+    return $informations;
+}


### PR DESCRIPTION
(WIP: Work In Progress)

Motivation

The 9.x version information is modified. Drupal Community changed the url from https://updates.drupal.org/release-history/drupal/9.x to https://updates.drupal.org/release-history/drupal/current.

What did I do?

The current url contains all supported Drupal version except 7. I am not an expert in bash and awk. I wrote a little PHP script which parse ".../current" and ".../7.x" release information and use it in update.sh.
It generate all supported Drupal version including 9.1.x-dev which is a development snapshot of next version of Drupal. 
Removed TODO for "switch to buster"

Issues

I can not test the generate-stackbrew-library.sh. How can I test it? I am afraid the "9.1.x-dev" will be the "latest", but it is not good. 

Related issue: Support Drupal 9 release #169