### PR TITLE
Pin to less specific Composer versions

### DIFF
--- a/8.9/php7.4/apache-buster/Dockerfile
+++ b/8.9/php7.4/apache-buster/Dockerfile
@@ -62,7 +62,7 @@ RUN { \
 		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
-COPY --from=composer:1.10 /usr/bin/composer /usr/local/bin/
+COPY --from=composer:1 /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
 ENV DRUPAL_VERSION 8.9.16

--- a/8.9/php7.4/fpm-alpine3.12/Dockerfile
+++ b/8.9/php7.4/fpm-alpine3.12/Dockerfile
@@ -52,7 +52,7 @@ RUN { \
 		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
-COPY --from=composer:1.10 /usr/bin/composer /usr/local/bin/
+COPY --from=composer:1 /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
 ENV DRUPAL_VERSION 8.9.16

--- a/8.9/php7.4/fpm-buster/Dockerfile
+++ b/8.9/php7.4/fpm-buster/Dockerfile
@@ -62,7 +62,7 @@ RUN { \
 		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
-COPY --from=composer:1.10 /usr/bin/composer /usr/local/bin/
+COPY --from=composer:1 /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
 ENV DRUPAL_VERSION 8.9.16

--- a/9.0/php7.4/apache-buster/Dockerfile
+++ b/9.0/php7.4/apache-buster/Dockerfile
@@ -62,7 +62,7 @@ RUN { \
 		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
-COPY --from=composer:1.10 /usr/bin/composer /usr/local/bin/
+COPY --from=composer:1 /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
 ENV DRUPAL_VERSION 9.0.14

--- a/9.0/php7.4/fpm-alpine3.12/Dockerfile
+++ b/9.0/php7.4/fpm-alpine3.12/Dockerfile
@@ -52,7 +52,7 @@ RUN { \
 		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
-COPY --from=composer:1.10 /usr/bin/composer /usr/local/bin/
+COPY --from=composer:1 /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
 ENV DRUPAL_VERSION 9.0.14

--- a/9.0/php7.4/fpm-buster/Dockerfile
+++ b/9.0/php7.4/fpm-buster/Dockerfile
@@ -62,7 +62,7 @@ RUN { \
 		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
-COPY --from=composer:1.10 /usr/bin/composer /usr/local/bin/
+COPY --from=composer:1 /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
 ENV DRUPAL_VERSION 9.0.14

--- a/9.1/php7.4/apache-buster/Dockerfile
+++ b/9.1/php7.4/apache-buster/Dockerfile
@@ -62,7 +62,7 @@ RUN { \
 		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
-COPY --from=composer:2.0 /usr/bin/composer /usr/local/bin/
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
 ENV DRUPAL_VERSION 9.1.9

--- a/9.1/php7.4/fpm-alpine3.12/Dockerfile
+++ b/9.1/php7.4/fpm-alpine3.12/Dockerfile
@@ -52,7 +52,7 @@ RUN { \
 		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
-COPY --from=composer:2.0 /usr/bin/composer /usr/local/bin/
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
 ENV DRUPAL_VERSION 9.1.9

--- a/9.1/php7.4/fpm-buster/Dockerfile
+++ b/9.1/php7.4/fpm-buster/Dockerfile
@@ -62,7 +62,7 @@ RUN { \
 		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
-COPY --from=composer:2.0 /usr/bin/composer /usr/local/bin/
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
 ENV DRUPAL_VERSION 9.1.9

--- a/9.1/php8.0/apache-buster/Dockerfile
+++ b/9.1/php8.0/apache-buster/Dockerfile
@@ -62,7 +62,7 @@ RUN { \
 		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
-COPY --from=composer:2.0 /usr/bin/composer /usr/local/bin/
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
 ENV DRUPAL_VERSION 9.1.9

--- a/9.1/php8.0/fpm-alpine3.12/Dockerfile
+++ b/9.1/php8.0/fpm-alpine3.12/Dockerfile
@@ -52,7 +52,7 @@ RUN { \
 		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
-COPY --from=composer:2.0 /usr/bin/composer /usr/local/bin/
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
 ENV DRUPAL_VERSION 9.1.9

--- a/9.1/php8.0/fpm-buster/Dockerfile
+++ b/9.1/php8.0/fpm-buster/Dockerfile
@@ -62,7 +62,7 @@ RUN { \
 		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
-COPY --from=composer:2.0 /usr/bin/composer /usr/local/bin/
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
 ENV DRUPAL_VERSION 9.1.9

--- a/versions.json
+++ b/versions.json
@@ -13,7 +13,7 @@
   },
   "8.9": {
     "composer": {
-      "version": "1.10"
+      "version": "1"
     },
     "md5": "d84c1abbdec51463cb062bafe42798f1",
     "phpVersions": [
@@ -28,7 +28,7 @@
   },
   "9.0": {
     "composer": {
-      "version": "1.10"
+      "version": "1"
     },
     "phpVersions": [
       "7.4"
@@ -42,7 +42,7 @@
   },
   "9.1": {
     "composer": {
-      "version": "2.0"
+      "version": "2"
     },
     "phpVersions": [
       "8.0",

--- a/versions.sh
+++ b/versions.sh
@@ -66,7 +66,7 @@ for version in "${versions[@]}"; do
 				(.packages, ."packages-dev")[]
 				| select(.name == "composer/composer")
 				| .version
-				| split(".")[0:2] | join(".")
+				| split(".")[0:1] | join(".")
 			' \
 			|| :
 	)"


### PR DESCRIPTION
Composer only maintains 1.x and 2.x -- with the release of 2.1, 2.0 is "EOL" (https://github.com/docker-library/official-images/pull/10297)