### PR TITLE
Add webp support

### DIFF
--- a/10.0-rc/php8.0/apache-bullseye/Dockerfile
+++ b/10.0-rc/php8.0/apache-bullseye/Dockerfile
@@ -22,12 +22,14 @@ RUN set -eux; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/10.0-rc/php8.0/apache-buster/Dockerfile
+++ b/10.0-rc/php8.0/apache-buster/Dockerfile
@@ -22,12 +22,14 @@ RUN set -eux; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/10.0-rc/php8.0/fpm-alpine3.14/Dockerfile
+++ b/10.0-rc/php8.0/fpm-alpine3.14/Dockerfile
@@ -15,6 +15,7 @@ RUN set -eux; \
 		freetype-dev \
 		libjpeg-turbo-dev \
 		libpng-dev \
+		libwebp-dev \
 		libzip-dev \
 # postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
 		postgresql-dev \
@@ -23,6 +24,7 @@ RUN set -eux; \
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr/include \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/10.0-rc/php8.0/fpm-alpine3.15/Dockerfile
+++ b/10.0-rc/php8.0/fpm-alpine3.15/Dockerfile
@@ -15,6 +15,7 @@ RUN set -eux; \
 		freetype-dev \
 		libjpeg-turbo-dev \
 		libpng-dev \
+		libwebp-dev \
 		libzip-dev \
 # postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
 		postgresql-dev \
@@ -23,6 +24,7 @@ RUN set -eux; \
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr/include \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/10.0-rc/php8.0/fpm-bullseye/Dockerfile
+++ b/10.0-rc/php8.0/fpm-bullseye/Dockerfile
@@ -22,12 +22,14 @@ RUN set -eux; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/10.0-rc/php8.0/fpm-buster/Dockerfile
+++ b/10.0-rc/php8.0/fpm-buster/Dockerfile
@@ -22,12 +22,14 @@ RUN set -eux; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/7/php7.4/apache-bullseye/Dockerfile
+++ b/7/php7.4/apache-bullseye/Dockerfile
@@ -22,12 +22,14 @@ RUN set -eux; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/7/php7.4/apache-buster/Dockerfile
+++ b/7/php7.4/apache-buster/Dockerfile
@@ -22,12 +22,14 @@ RUN set -eux; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/7/php7.4/fpm-alpine3.14/Dockerfile
+++ b/7/php7.4/fpm-alpine3.14/Dockerfile
@@ -15,6 +15,7 @@ RUN set -eux; \
 		freetype-dev \
 		libjpeg-turbo-dev \
 		libpng-dev \
+		libwebp-dev \
 		libzip-dev \
 # postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
 		postgresql-dev \
@@ -23,6 +24,7 @@ RUN set -eux; \
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr/include \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/7/php7.4/fpm-alpine3.15/Dockerfile
+++ b/7/php7.4/fpm-alpine3.15/Dockerfile
@@ -15,6 +15,7 @@ RUN set -eux; \
 		freetype-dev \
 		libjpeg-turbo-dev \
 		libpng-dev \
+		libwebp-dev \
 		libzip-dev \
 # postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
 		postgresql-dev \
@@ -23,6 +24,7 @@ RUN set -eux; \
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr/include \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/7/php7.4/fpm-bullseye/Dockerfile
+++ b/7/php7.4/fpm-bullseye/Dockerfile
@@ -22,12 +22,14 @@ RUN set -eux; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/7/php7.4/fpm-buster/Dockerfile
+++ b/7/php7.4/fpm-buster/Dockerfile
@@ -22,12 +22,14 @@ RUN set -eux; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/9.2/php7.4/apache-bullseye/Dockerfile
+++ b/9.2/php7.4/apache-bullseye/Dockerfile
@@ -22,12 +22,14 @@ RUN set -eux; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/9.2/php7.4/apache-buster/Dockerfile
+++ b/9.2/php7.4/apache-buster/Dockerfile
@@ -22,12 +22,14 @@ RUN set -eux; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/9.2/php7.4/fpm-alpine3.14/Dockerfile
+++ b/9.2/php7.4/fpm-alpine3.14/Dockerfile
@@ -15,6 +15,7 @@ RUN set -eux; \
 		freetype-dev \
 		libjpeg-turbo-dev \
 		libpng-dev \
+		libwebp-dev \
 		libzip-dev \
 # postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
 		postgresql-dev \
@@ -23,6 +24,7 @@ RUN set -eux; \
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr/include \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/9.2/php7.4/fpm-alpine3.15/Dockerfile
+++ b/9.2/php7.4/fpm-alpine3.15/Dockerfile
@@ -15,6 +15,7 @@ RUN set -eux; \
 		freetype-dev \
 		libjpeg-turbo-dev \
 		libpng-dev \
+		libwebp-dev \
 		libzip-dev \
 # postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
 		postgresql-dev \
@@ -23,6 +24,7 @@ RUN set -eux; \
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr/include \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/9.2/php7.4/fpm-bullseye/Dockerfile
+++ b/9.2/php7.4/fpm-bullseye/Dockerfile
@@ -22,12 +22,14 @@ RUN set -eux; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/9.2/php7.4/fpm-buster/Dockerfile
+++ b/9.2/php7.4/fpm-buster/Dockerfile
@@ -22,12 +22,14 @@ RUN set -eux; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/9.2/php8.0/apache-bullseye/Dockerfile
+++ b/9.2/php8.0/apache-bullseye/Dockerfile
@@ -22,12 +22,14 @@ RUN set -eux; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/9.2/php8.0/apache-buster/Dockerfile
+++ b/9.2/php8.0/apache-buster/Dockerfile
@@ -22,12 +22,14 @@ RUN set -eux; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/9.2/php8.0/fpm-alpine3.14/Dockerfile
+++ b/9.2/php8.0/fpm-alpine3.14/Dockerfile
@@ -15,6 +15,7 @@ RUN set -eux; \
 		freetype-dev \
 		libjpeg-turbo-dev \
 		libpng-dev \
+		libwebp-dev \
 		libzip-dev \
 # postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
 		postgresql-dev \
@@ -23,6 +24,7 @@ RUN set -eux; \
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr/include \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/9.2/php8.0/fpm-alpine3.15/Dockerfile
+++ b/9.2/php8.0/fpm-alpine3.15/Dockerfile
@@ -15,6 +15,7 @@ RUN set -eux; \
 		freetype-dev \
 		libjpeg-turbo-dev \
 		libpng-dev \
+		libwebp-dev \
 		libzip-dev \
 # postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
 		postgresql-dev \
@@ -23,6 +24,7 @@ RUN set -eux; \
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr/include \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/9.2/php8.0/fpm-bullseye/Dockerfile
+++ b/9.2/php8.0/fpm-bullseye/Dockerfile
@@ -22,12 +22,14 @@ RUN set -eux; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/9.2/php8.0/fpm-buster/Dockerfile
+++ b/9.2/php8.0/fpm-buster/Dockerfile
@@ -22,12 +22,14 @@ RUN set -eux; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/9.3/php7.4/apache-bullseye/Dockerfile
+++ b/9.3/php7.4/apache-bullseye/Dockerfile
@@ -22,12 +22,14 @@ RUN set -eux; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/9.3/php7.4/apache-buster/Dockerfile
+++ b/9.3/php7.4/apache-buster/Dockerfile
@@ -22,12 +22,14 @@ RUN set -eux; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/9.3/php7.4/fpm-alpine3.14/Dockerfile
+++ b/9.3/php7.4/fpm-alpine3.14/Dockerfile
@@ -15,6 +15,7 @@ RUN set -eux; \
 		freetype-dev \
 		libjpeg-turbo-dev \
 		libpng-dev \
+		libwebp-dev \
 		libzip-dev \
 # postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
 		postgresql-dev \
@@ -23,6 +24,7 @@ RUN set -eux; \
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr/include \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/9.3/php7.4/fpm-alpine3.15/Dockerfile
+++ b/9.3/php7.4/fpm-alpine3.15/Dockerfile
@@ -15,6 +15,7 @@ RUN set -eux; \
 		freetype-dev \
 		libjpeg-turbo-dev \
 		libpng-dev \
+		libwebp-dev \
 		libzip-dev \
 # postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
 		postgresql-dev \
@@ -23,6 +24,7 @@ RUN set -eux; \
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr/include \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/9.3/php7.4/fpm-bullseye/Dockerfile
+++ b/9.3/php7.4/fpm-bullseye/Dockerfile
@@ -22,12 +22,14 @@ RUN set -eux; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/9.3/php7.4/fpm-buster/Dockerfile
+++ b/9.3/php7.4/fpm-buster/Dockerfile
@@ -22,12 +22,14 @@ RUN set -eux; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/9.3/php8.0/apache-bullseye/Dockerfile
+++ b/9.3/php8.0/apache-bullseye/Dockerfile
@@ -22,12 +22,14 @@ RUN set -eux; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/9.3/php8.0/apache-buster/Dockerfile
+++ b/9.3/php8.0/apache-buster/Dockerfile
@@ -22,12 +22,14 @@ RUN set -eux; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/9.3/php8.0/fpm-alpine3.14/Dockerfile
+++ b/9.3/php8.0/fpm-alpine3.14/Dockerfile
@@ -15,6 +15,7 @@ RUN set -eux; \
 		freetype-dev \
 		libjpeg-turbo-dev \
 		libpng-dev \
+		libwebp-dev \
 		libzip-dev \
 # postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
 		postgresql-dev \
@@ -23,6 +24,7 @@ RUN set -eux; \
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr/include \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/9.3/php8.0/fpm-alpine3.15/Dockerfile
+++ b/9.3/php8.0/fpm-alpine3.15/Dockerfile
@@ -15,6 +15,7 @@ RUN set -eux; \
 		freetype-dev \
 		libjpeg-turbo-dev \
 		libpng-dev \
+		libwebp-dev \
 		libzip-dev \
 # postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
 		postgresql-dev \
@@ -23,6 +24,7 @@ RUN set -eux; \
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr/include \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/9.3/php8.0/fpm-bullseye/Dockerfile
+++ b/9.3/php8.0/fpm-bullseye/Dockerfile
@@ -22,12 +22,14 @@ RUN set -eux; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/9.3/php8.0/fpm-buster/Dockerfile
+++ b/9.3/php8.0/fpm-buster/Dockerfile
@@ -22,12 +22,14 @@ RUN set -eux; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libwebp-dev \
 		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg=/usr \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -14,6 +14,7 @@ RUN set -eux; \
 		freetype-dev \
 		libjpeg-turbo-dev \
 		libpng-dev \
+		libwebp-dev \
 		libzip-dev \
 # postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
 		postgresql-dev \
@@ -30,6 +31,7 @@ RUN set -eux; \
 		libjpeg-dev \
 		libpng-dev \
 		libpq-dev \
+		libwebp-dev \
 		libzip-dev \
 {{ ) end -}}
 	; \
@@ -37,6 +39,7 @@ RUN set -eux; \
 	docker-php-ext-configure gd \
 		--with-freetype \
 		--with-jpeg={{ if is_alpine then "/usr/include" else "/usr" end }} \
+		--with-webp \
 	; \
 	\
 	docker-php-ext-install -j "$(nproc)" \


### PR DESCRIPTION
Here are the issues that were tracking upstream support:
- `9.2.x-dev`: https://www.drupal.org/project/drupal/issues/2340699
- `7.x-dev`: https://www.drupal.org/project/drupal/issues/3179554

Fixes https://github.com/docker-library/drupal/issues/209
Related to https://github.com/docker-library/wordpress/pull/644