### PR TITLE
Add support to run distributions

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -105,7 +105,7 @@ RUN set -eux; \
 WORKDIR /opt/drupal
 RUN set -eux; \
 	export COMPOSER_HOME="$(mktemp -d)"; \
-	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
+	composer create-project --no-interaction "${DRUPAL_DISTRIBUTION:-drupal/recommended-project}:$DRUPAL_VERSION" ./; \
 	chown -R www-data:www-data web/sites web/modules web/themes; \
 	rmdir /var/www/html; \
 	ln -sf /opt/drupal/web /var/www/html; \


### PR DESCRIPTION
**What I like to do?**

Be able to use the community drupal image to install a drupal-distribution (like thunder or varbase).

**Problem I like to solve?**

Taking thunder as an example, over this image I can create a derivative and "RUN composer create-project thunder/thunder-project ..."  to overwrite the existing version (or install side to side) but it will create a new layer over the vanilla-drupal one (bigger images) and it will be tricky with persistent folders you always like to map (sites, modules, themes...).

**Solution?**

Modify existing image template to take a variable and be able to install distributions if a env variable is set.

**How?**

Maybe a modification of the compose call would be enough?
https://github.com/docker-library/drupal/blob/155d43499e8b4db568a5ca8ade1997d79107e2f7/Dockerfile.template#L108

PR sent adding an env variable with default value (to guarantee all will keep working as before) as follows:

 ```
composer create-project --no-interaction "${DRUPAL_DISTRIBUTION:-drupal/recommended-project}:$DRUPAL_VERSION" ./; \
```

Thanks a lot for your work,
m.