### PR TITLE
Drupal 10 now requires php 8.1

### DIFF
--- a/10.0-rc/php8.1/apache-bullseye/Dockerfile
+++ b/10.0-rc/php8.1/apache-bullseye/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # from https://www.drupal.org/docs/system-requirements/php-requirements
-FROM php:8.0-apache-bullseye
+FROM php:8.1-apache-bullseye
 
 # install the PHP extensions we need
 RUN set -eux; \
@@ -67,7 +67,7 @@ RUN { \
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 10.0.0-alpha1
+ENV DRUPAL_VERSION 10.0.0-alpha2
 
 WORKDIR /opt/drupal
 RUN set -eux; \

--- a/10.0-rc/php8.1/apache-buster/Dockerfile
+++ b/10.0-rc/php8.1/apache-buster/Dockerfile
@@ -5,25 +5,30 @@
 #
 
 # from https://www.drupal.org/docs/system-requirements/php-requirements
-FROM php:8.0-fpm-alpine3.15
+FROM php:8.1-apache-buster
 
 # install the PHP extensions we need
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .build-deps \
-		coreutils \
-		freetype-dev \
-		libjpeg-turbo-dev \
+	if command -v a2enmod; then \
+		a2enmod rewrite; \
+	fi; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libfreetype6-dev \
+		libjpeg-dev \
 		libpng-dev \
+		libpq-dev \
 		libwebp-dev \
 		libzip-dev \
-# postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
-		postgresql-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
-		--with-jpeg=/usr/include \
+		--with-jpeg=/usr \
 		--with-webp \
 	; \
 	\
@@ -35,14 +40,19 @@ RUN set -eux; \
 		zip \
 	; \
 	\
-	runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
-			| tr ',' '\n' \
-			| sort -u \
-			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-	)"; \
-	apk add --no-network --virtual .drupal-phpexts-rundeps $runDeps; \
-	apk del --no-network .build-deps
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { print $3 }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php
@@ -57,7 +67,7 @@ RUN { \
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 10.0.0-alpha1
+ENV DRUPAL_VERSION 10.0.0-alpha2
 
 WORKDIR /opt/drupal
 RUN set -eux; \

--- a/10.0-rc/php8.1/fpm-alpine3.14/Dockerfile
+++ b/10.0-rc/php8.1/fpm-alpine3.14/Dockerfile
@@ -5,30 +5,25 @@
 #
 
 # from https://www.drupal.org/docs/system-requirements/php-requirements
-FROM php:8.0-apache-buster
+FROM php:8.1-fpm-alpine3.14
 
 # install the PHP extensions we need
 RUN set -eux; \
 	\
-	if command -v a2enmod; then \
-		a2enmod rewrite; \
-	fi; \
-	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	\
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		libfreetype6-dev \
-		libjpeg-dev \
+	apk add --no-cache --virtual .build-deps \
+		coreutils \
+		freetype-dev \
+		libjpeg-turbo-dev \
 		libpng-dev \
-		libpq-dev \
 		libwebp-dev \
 		libzip-dev \
+# postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
+		postgresql-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
-		--with-jpeg=/usr \
+		--with-jpeg=/usr/include \
 		--with-webp \
 	; \
 	\
@@ -40,19 +35,14 @@ RUN set -eux; \
 		zip \
 	; \
 	\
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
-	apt-mark auto '.*' > /dev/null; \
-	apt-mark manual $savedAptMark; \
-	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
-		| awk '/=>/ { print $3 }' \
-		| sort -u \
-		| xargs -r dpkg-query -S \
-		| cut -d: -f1 \
-		| sort -u \
-		| xargs -rt apt-mark manual; \
-	\
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*
+	runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)"; \
+	apk add --no-network --virtual .drupal-phpexts-rundeps $runDeps; \
+	apk del --no-network .build-deps
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php
@@ -67,7 +57,7 @@ RUN { \
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 10.0.0-alpha1
+ENV DRUPAL_VERSION 10.0.0-alpha2
 
 WORKDIR /opt/drupal
 RUN set -eux; \

--- a/10.0-rc/php8.1/fpm-alpine3.15/Dockerfile
+++ b/10.0-rc/php8.1/fpm-alpine3.15/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # from https://www.drupal.org/docs/system-requirements/php-requirements
-FROM php:8.0-fpm-alpine3.14
+FROM php:8.1-fpm-alpine3.15
 
 # install the PHP extensions we need
 RUN set -eux; \
@@ -57,7 +57,7 @@ RUN { \
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 10.0.0-alpha1
+ENV DRUPAL_VERSION 10.0.0-alpha2
 
 WORKDIR /opt/drupal
 RUN set -eux; \

--- a/10.0-rc/php8.1/fpm-bullseye/Dockerfile
+++ b/10.0-rc/php8.1/fpm-bullseye/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # from https://www.drupal.org/docs/system-requirements/php-requirements
-FROM php:8.0-fpm-buster
+FROM php:8.1-fpm-bullseye
 
 # install the PHP extensions we need
 RUN set -eux; \
@@ -67,7 +67,7 @@ RUN { \
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 10.0.0-alpha1
+ENV DRUPAL_VERSION 10.0.0-alpha2
 
 WORKDIR /opt/drupal
 RUN set -eux; \

--- a/10.0-rc/php8.1/fpm-buster/Dockerfile
+++ b/10.0-rc/php8.1/fpm-buster/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # from https://www.drupal.org/docs/system-requirements/php-requirements
-FROM php:8.0-fpm-bullseye
+FROM php:8.1-fpm-buster
 
 # install the PHP extensions we need
 RUN set -eux; \
@@ -67,7 +67,7 @@ RUN { \
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 10.0.0-alpha1
+ENV DRUPAL_VERSION 10.0.0-alpha2
 
 WORKDIR /opt/drupal
 RUN set -eux; \

--- a/versions.json
+++ b/versions.json
@@ -4,7 +4,7 @@
       "version": "2"
     },
     "phpVersions": [
-      "8.0"
+      "8.1"
     ],
     "variants": [
       "apache-bullseye",
@@ -14,7 +14,7 @@
       "fpm-alpine3.15",
       "fpm-alpine3.14"
     ],
-    "version": "10.0.0-alpha1"
+    "version": "10.0.0-alpha2"
   },
   "7": {
     "md5": "924e707e3b1e8269fe623cf2f22ee710",

--- a/versions.sh
+++ b/versions.sh
@@ -101,9 +101,9 @@ for version in "${versions[@]}"; do
 					elif env.version | startswith("9.") then
 						[ "8.0", "7.4" ]
 					else
-						# https://www.drupal.org/project/drupal/issues/3118147
-						# Require PHP 8 for Drupal 10
-						[ "8.0" ]
+						# https://www.drupal.org/node/3264830
+						# Require PHP 8.1 for Drupal 10
+						[ "8.1" ]
 					end
 				),
 			} + $doc


### PR DESCRIPTION
Update.sh jobs were failing for `10.0.0-alpha2`:
```console
drupal/core 10.0.0-alpha2 requires php >=8.1.0 -> your php version (8.0.16) does not satisfy that requirement
```

They changed the minimum https://www.drupal.org/node/3264830