### PR TITLE
Fix default PHP version for 10+

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -11,10 +11,12 @@ declare -A debianSuites=(
 	#[9.2]='buster'
 )
 
-defaultPhpVersion='php8.0'
+defaultPhpVersion='php8.1'
 declare -A defaultPhpVersions=(
 # https://www.drupal.org/docs/7/system-requirements/php-requirements#php_required
 	[7]='php7.4'
+	[9.2]='php8.0'
+	[9.3]='php8.0'
 )
 
 self="$(basename "$BASH_SOURCE")"


### PR DESCRIPTION
```diff
--- ../official-images/library/drupal	2022-06-13 13:09:55.638530107 -0700
+++ /dev/fd/63	2022-06-13 14:27:58.876245257 -0700
@@ -4,32 +4,32 @@
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 10.0.0-alpha5-php8.1-apache-bullseye, 10.0-rc-php8.1-apache-bullseye, rc-php8.1-apache-bullseye, 10.0.0-alpha5-php8.1-apache, 10.0-rc-php8.1-apache, rc-php8.1-apache, 10.0.0-alpha5-php8.1, 10.0-rc-php8.1, rc-php8.1
+Tags: 10.0.0-alpha5-php8.1-apache-bullseye, 10.0-rc-php8.1-apache-bullseye, rc-php8.1-apache-bullseye, 10.0.0-alpha5-php8.1-apache, 10.0-rc-php8.1-apache, rc-php8.1-apache, 10.0.0-alpha5-php8.1, 10.0-rc-php8.1, rc-php8.1, 10.0.0-alpha5-apache-bullseye, 10.0-rc-apache-bullseye, rc-apache-bullseye, 10.0.0-alpha5-apache, 10.0-rc-apache, rc-apache, 10.0.0-alpha5, 10.0-rc, rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0d4851818464177c484260a755103228eb83f64b
 Directory: 10.0-rc/php8.1/apache-bullseye
 
-Tags: 10.0.0-alpha5-php8.1-fpm-bullseye, 10.0-rc-php8.1-fpm-bullseye, rc-php8.1-fpm-bullseye, 10.0.0-alpha5-php8.1-fpm, 10.0-rc-php8.1-fpm, rc-php8.1-fpm
+Tags: 10.0.0-alpha5-php8.1-fpm-bullseye, 10.0-rc-php8.1-fpm-bullseye, rc-php8.1-fpm-bullseye, 10.0.0-alpha5-php8.1-fpm, 10.0-rc-php8.1-fpm, rc-php8.1-fpm, 10.0.0-alpha5-fpm-bullseye, 10.0-rc-fpm-bullseye, rc-fpm-bullseye, 10.0.0-alpha5-fpm, 10.0-rc-fpm, rc-fpm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0d4851818464177c484260a755103228eb83f64b
 Directory: 10.0-rc/php8.1/fpm-bullseye
 
-Tags: 10.0.0-alpha5-php8.1-apache-buster, 10.0-rc-php8.1-apache-buster, rc-php8.1-apache-buster
+Tags: 10.0.0-alpha5-php8.1-apache-buster, 10.0-rc-php8.1-apache-buster, rc-php8.1-apache-buster, 10.0.0-alpha5-apache-buster, 10.0-rc-apache-buster, rc-apache-buster
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0d4851818464177c484260a755103228eb83f64b
 Directory: 10.0-rc/php8.1/apache-buster
 
-Tags: 10.0.0-alpha5-php8.1-fpm-buster, 10.0-rc-php8.1-fpm-buster, rc-php8.1-fpm-buster
+Tags: 10.0.0-alpha5-php8.1-fpm-buster, 10.0-rc-php8.1-fpm-buster, rc-php8.1-fpm-buster, 10.0.0-alpha5-fpm-buster, 10.0-rc-fpm-buster, rc-fpm-buster
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0d4851818464177c484260a755103228eb83f64b
 Directory: 10.0-rc/php8.1/fpm-buster
 
-Tags: 10.0.0-alpha5-php8.1-fpm-alpine3.16, 10.0-rc-php8.1-fpm-alpine3.16, rc-php8.1-fpm-alpine3.16, 10.0.0-alpha5-php8.1-fpm-alpine, 10.0-rc-php8.1-fpm-alpine, rc-php8.1-fpm-alpine
+Tags: 10.0.0-alpha5-php8.1-fpm-alpine3.16, 10.0-rc-php8.1-fpm-alpine3.16, rc-php8.1-fpm-alpine3.16, 10.0.0-alpha5-php8.1-fpm-alpine, 10.0-rc-php8.1-fpm-alpine, rc-php8.1-fpm-alpine, 10.0.0-alpha5-fpm-alpine3.16, 10.0-rc-fpm-alpine3.16, rc-fpm-alpine3.16, 10.0.0-alpha5-fpm-alpine, 10.0-rc-fpm-alpine, rc-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0d4851818464177c484260a755103228eb83f64b
 Directory: 10.0-rc/php8.1/fpm-alpine3.16
 
-Tags: 10.0.0-alpha5-php8.1-fpm-alpine3.15, 10.0-rc-php8.1-fpm-alpine3.15, rc-php8.1-fpm-alpine3.15
+Tags: 10.0.0-alpha5-php8.1-fpm-alpine3.15, 10.0-rc-php8.1-fpm-alpine3.15, rc-php8.1-fpm-alpine3.15, 10.0.0-alpha5-fpm-alpine3.15, 10.0-rc-fpm-alpine3.15, rc-fpm-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0d4851818464177c484260a755103228eb83f64b
 Directory: 10.0-rc/php8.1/fpm-alpine3.15
```