### PR TITLE
Update 10.0 to GA release

### DIFF
--- a/10.0/php8.1/apache-bullseye/Dockerfile
+++ b/10.0/php8.1/apache-bullseye/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # from https://www.drupal.org/docs/system-requirements/php-requirements
-FROM php:8.2-fpm-buster
+FROM php:8.1-apache-bullseye
 
 # install the PHP extensions we need
 RUN set -eux; \
@@ -67,7 +67,7 @@ RUN { \
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 10.0.0-rc3
+ENV DRUPAL_VERSION 10.0.0
 
 WORKDIR /opt/drupal
 RUN set -eux; \

--- a/10.0/php8.1/apache-buster/Dockerfile
+++ b/10.0/php8.1/apache-buster/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # from https://www.drupal.org/docs/system-requirements/php-requirements
-FROM php:8.1-fpm-buster
+FROM php:8.1-apache-buster
 
 # install the PHP extensions we need
 RUN set -eux; \
@@ -67,7 +67,7 @@ RUN { \
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 10.0.0-rc3
+ENV DRUPAL_VERSION 10.0.0
 
 WORKDIR /opt/drupal
 RUN set -eux; \

--- a/10.0/php8.1/fpm-alpine3.16/Dockerfile
+++ b/10.0/php8.1/fpm-alpine3.16/Dockerfile
@@ -5,30 +5,25 @@
 #
 
 # from https://www.drupal.org/docs/system-requirements/php-requirements
-FROM php:8.1-fpm-bullseye
+FROM php:8.1-fpm-alpine3.16
 
 # install the PHP extensions we need
 RUN set -eux; \
 	\
-	if command -v a2enmod; then \
-		a2enmod rewrite; \
-	fi; \
-	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	\
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		libfreetype6-dev \
-		libjpeg-dev \
+	apk add --no-cache --virtual .build-deps \
+		coreutils \
+		freetype-dev \
+		libjpeg-turbo-dev \
 		libpng-dev \
-		libpq-dev \
 		libwebp-dev \
 		libzip-dev \
+# postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
+		postgresql-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
-		--with-jpeg=/usr \
+		--with-jpeg=/usr/include \
 		--with-webp \
 	; \
 	\
@@ -40,19 +35,14 @@ RUN set -eux; \
 		zip \
 	; \
 	\
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
-	apt-mark auto '.*' > /dev/null; \
-	apt-mark manual $savedAptMark; \
-	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
-		| awk '/=>/ { print $3 }' \
-		| sort -u \
-		| xargs -r dpkg-query -S \
-		| cut -d: -f1 \
-		| sort -u \
-		| xargs -rt apt-mark manual; \
-	\
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*
+	runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)"; \
+	apk add --no-network --virtual .drupal-phpexts-rundeps $runDeps; \
+	apk del --no-network .build-deps
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php
@@ -67,7 +57,7 @@ RUN { \
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 10.0.0-rc3
+ENV DRUPAL_VERSION 10.0.0
 
 WORKDIR /opt/drupal
 RUN set -eux; \

--- a/10.0/php8.1/fpm-alpine3.17/Dockerfile
+++ b/10.0/php8.1/fpm-alpine3.17/Dockerfile
@@ -5,30 +5,25 @@
 #
 
 # from https://www.drupal.org/docs/system-requirements/php-requirements
-FROM php:8.1-apache-bullseye
+FROM php:8.1-fpm-alpine3.17
 
 # install the PHP extensions we need
 RUN set -eux; \
 	\
-	if command -v a2enmod; then \
-		a2enmod rewrite; \
-	fi; \
-	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	\
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		libfreetype6-dev \
-		libjpeg-dev \
+	apk add --no-cache --virtual .build-deps \
+		coreutils \
+		freetype-dev \
+		libjpeg-turbo-dev \
 		libpng-dev \
-		libpq-dev \
 		libwebp-dev \
 		libzip-dev \
+# postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
+		postgresql-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
-		--with-jpeg=/usr \
+		--with-jpeg=/usr/include \
 		--with-webp \
 	; \
 	\
@@ -40,19 +35,14 @@ RUN set -eux; \
 		zip \
 	; \
 	\
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
-	apt-mark auto '.*' > /dev/null; \
-	apt-mark manual $savedAptMark; \
-	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
-		| awk '/=>/ { print $3 }' \
-		| sort -u \
-		| xargs -r dpkg-query -S \
-		| cut -d: -f1 \
-		| sort -u \
-		| xargs -rt apt-mark manual; \
-	\
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*
+	runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)"; \
+	apk add --no-network --virtual .drupal-phpexts-rundeps $runDeps; \
+	apk del --no-network .build-deps
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php
@@ -67,7 +57,7 @@ RUN { \
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 10.0.0-rc3
+ENV DRUPAL_VERSION 10.0.0
 
 WORKDIR /opt/drupal
 RUN set -eux; \

--- a/10.0/php8.1/fpm-bullseye/Dockerfile
+++ b/10.0/php8.1/fpm-bullseye/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # from https://www.drupal.org/docs/system-requirements/php-requirements
-FROM php:8.1-apache-buster
+FROM php:8.1-fpm-bullseye
 
 # install the PHP extensions we need
 RUN set -eux; \
@@ -67,7 +67,7 @@ RUN { \
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 10.0.0-rc3
+ENV DRUPAL_VERSION 10.0.0
 
 WORKDIR /opt/drupal
 RUN set -eux; \

--- a/10.0/php8.1/fpm-buster/Dockerfile
+++ b/10.0/php8.1/fpm-buster/Dockerfile
@@ -5,25 +5,30 @@
 #
 
 # from https://www.drupal.org/docs/system-requirements/php-requirements
-FROM php:8.1-fpm-alpine3.17
+FROM php:8.1-fpm-buster
 
 # install the PHP extensions we need
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .build-deps \
-		coreutils \
-		freetype-dev \
-		libjpeg-turbo-dev \
+	if command -v a2enmod; then \
+		a2enmod rewrite; \
+	fi; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libfreetype6-dev \
+		libjpeg-dev \
 		libpng-dev \
+		libpq-dev \
 		libwebp-dev \
 		libzip-dev \
-# postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
-		postgresql-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
-		--with-jpeg=/usr/include \
+		--with-jpeg=/usr \
 		--with-webp \
 	; \
 	\
@@ -35,14 +40,19 @@ RUN set -eux; \
 		zip \
 	; \
 	\
-	runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
-			| tr ',' '\n' \
-			| sort -u \
-			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-	)"; \
-	apk add --no-network --virtual .drupal-phpexts-rundeps $runDeps; \
-	apk del --no-network .build-deps
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { print $3 }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php
@@ -57,7 +67,7 @@ RUN { \
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 10.0.0-rc3
+ENV DRUPAL_VERSION 10.0.0
 
 WORKDIR /opt/drupal
 RUN set -eux; \

--- a/10.0/php8.2/apache-bullseye/Dockerfile
+++ b/10.0/php8.2/apache-bullseye/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # from https://www.drupal.org/docs/system-requirements/php-requirements
-FROM php:8.2-fpm-bullseye
+FROM php:8.2-apache-bullseye
 
 # install the PHP extensions we need
 RUN set -eux; \
@@ -67,7 +67,7 @@ RUN { \
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 10.0.0-rc3
+ENV DRUPAL_VERSION 10.0.0
 
 WORKDIR /opt/drupal
 RUN set -eux; \

--- a/10.0/php8.2/apache-buster/Dockerfile
+++ b/10.0/php8.2/apache-buster/Dockerfile
@@ -5,25 +5,30 @@
 #
 
 # from https://www.drupal.org/docs/system-requirements/php-requirements
-FROM php:8.1-fpm-alpine3.16
+FROM php:8.2-apache-buster
 
 # install the PHP extensions we need
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .build-deps \
-		coreutils \
-		freetype-dev \
-		libjpeg-turbo-dev \
+	if command -v a2enmod; then \
+		a2enmod rewrite; \
+	fi; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libfreetype6-dev \
+		libjpeg-dev \
 		libpng-dev \
+		libpq-dev \
 		libwebp-dev \
 		libzip-dev \
-# postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
-		postgresql-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
-		--with-jpeg=/usr/include \
+		--with-jpeg=/usr \
 		--with-webp \
 	; \
 	\
@@ -35,14 +40,19 @@ RUN set -eux; \
 		zip \
 	; \
 	\
-	runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
-			| tr ',' '\n' \
-			| sort -u \
-			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-	)"; \
-	apk add --no-network --virtual .drupal-phpexts-rundeps $runDeps; \
-	apk del --no-network .build-deps
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { print $3 }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php
@@ -57,7 +67,7 @@ RUN { \
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 10.0.0-rc3
+ENV DRUPAL_VERSION 10.0.0
 
 WORKDIR /opt/drupal
 RUN set -eux; \

--- a/10.0/php8.2/fpm-alpine3.16/Dockerfile
+++ b/10.0/php8.2/fpm-alpine3.16/Dockerfile
@@ -57,7 +57,7 @@ RUN { \
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 10.0.0-rc3
+ENV DRUPAL_VERSION 10.0.0
 
 WORKDIR /opt/drupal
 RUN set -eux; \

--- a/10.0/php8.2/fpm-alpine3.17/Dockerfile
+++ b/10.0/php8.2/fpm-alpine3.17/Dockerfile
@@ -5,30 +5,25 @@
 #
 
 # from https://www.drupal.org/docs/system-requirements/php-requirements
-FROM php:8.2-apache-bullseye
+FROM php:8.2-fpm-alpine3.17
 
 # install the PHP extensions we need
 RUN set -eux; \
 	\
-	if command -v a2enmod; then \
-		a2enmod rewrite; \
-	fi; \
-	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	\
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		libfreetype6-dev \
-		libjpeg-dev \
+	apk add --no-cache --virtual .build-deps \
+		coreutils \
+		freetype-dev \
+		libjpeg-turbo-dev \
 		libpng-dev \
-		libpq-dev \
 		libwebp-dev \
 		libzip-dev \
+# postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
+		postgresql-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
-		--with-jpeg=/usr \
+		--with-jpeg=/usr/include \
 		--with-webp \
 	; \
 	\
@@ -40,19 +35,14 @@ RUN set -eux; \
 		zip \
 	; \
 	\
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
-	apt-mark auto '.*' > /dev/null; \
-	apt-mark manual $savedAptMark; \
-	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
-		| awk '/=>/ { print $3 }' \
-		| sort -u \
-		| xargs -r dpkg-query -S \
-		| cut -d: -f1 \
-		| sort -u \
-		| xargs -rt apt-mark manual; \
-	\
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*
+	runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)"; \
+	apk add --no-network --virtual .drupal-phpexts-rundeps $runDeps; \
+	apk del --no-network .build-deps
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php
@@ -67,7 +57,7 @@ RUN { \
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 10.0.0-rc3
+ENV DRUPAL_VERSION 10.0.0
 
 WORKDIR /opt/drupal
 RUN set -eux; \

--- a/10.0/php8.2/fpm-bullseye/Dockerfile
+++ b/10.0/php8.2/fpm-bullseye/Dockerfile
@@ -5,25 +5,30 @@
 #
 
 # from https://www.drupal.org/docs/system-requirements/php-requirements
-FROM php:8.2-fpm-alpine3.17
+FROM php:8.2-fpm-bullseye
 
 # install the PHP extensions we need
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .build-deps \
-		coreutils \
-		freetype-dev \
-		libjpeg-turbo-dev \
+	if command -v a2enmod; then \
+		a2enmod rewrite; \
+	fi; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libfreetype6-dev \
+		libjpeg-dev \
 		libpng-dev \
+		libpq-dev \
 		libwebp-dev \
 		libzip-dev \
-# postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
-		postgresql-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
-		--with-jpeg=/usr/include \
+		--with-jpeg=/usr \
 		--with-webp \
 	; \
 	\
@@ -35,14 +40,19 @@ RUN set -eux; \
 		zip \
 	; \
 	\
-	runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
-			| tr ',' '\n' \
-			| sort -u \
-			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-	)"; \
-	apk add --no-network --virtual .drupal-phpexts-rundeps $runDeps; \
-	apk del --no-network .build-deps
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { print $3 }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php
@@ -57,7 +67,7 @@ RUN { \
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 10.0.0-rc3
+ENV DRUPAL_VERSION 10.0.0
 
 WORKDIR /opt/drupal
 RUN set -eux; \

--- a/10.0/php8.2/fpm-buster/Dockerfile
+++ b/10.0/php8.2/fpm-buster/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # from https://www.drupal.org/docs/system-requirements/php-requirements
-FROM php:8.2-apache-buster
+FROM php:8.2-fpm-buster
 
 # install the PHP extensions we need
 RUN set -eux; \
@@ -67,7 +67,7 @@ RUN { \
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 10.0.0-rc3
+ENV DRUPAL_VERSION 10.0.0
 
 WORKDIR /opt/drupal
 RUN set -eux; \

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -2,8 +2,9 @@
 set -Eeuo pipefail
 
 declare -A aliases=(
-	[9.5]='9 latest'
-	[10.0-rc]='rc'
+	[9.5]='9'
+	[10.0]='10 latest'
+	[10.1-rc]='rc'
 )
 
 defaultDebianSuite='bullseye'

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,5 @@
 {
-  "10.0-rc": {
+  "10.0": {
     "composer": {
       "version": "2"
     },
@@ -15,7 +15,7 @@
       "fpm-alpine3.17",
       "fpm-alpine3.16"
     ],
-    "version": "10.0.0-rc3"
+    "version": "10.0.0"
   },
   "7": {
     "md5": "dae634ea0da005c5c435cfa9a9c5c322",


### PR DESCRIPTION
Also update `latest` tag and add `10`.

Fixes https://github.com/docker-library/drupal/issues/234

```diff
--- ../official-images/library/drupal	2022-12-16 16:40:57.125390611 -0800
+++ /dev/fd/63	2023-01-03 15:21:54.123478357 -0800
@@ -1,120 +1,120 @@
-# this file is generated via https://github.com/docker-library/drupal/blob/19559d62d44c5b3d7fe69a957e6154da08300fd9/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/drupal/blob/85787d8d84242e96e9976f68810025444ae0db4c/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git
 
-Tags: 10.0.0-rc3-php8.2-apache-bullseye, 10.0-rc-php8.2-apache-bullseye, rc-php8.2-apache-bullseye, 10.0.0-rc3-php8.2-apache, 10.0-rc-php8.2-apache, rc-php8.2-apache, 10.0.0-rc3-php8.2, 10.0-rc-php8.2, rc-php8.2, 10.0.0-rc3-apache-bullseye, 10.0-rc-apache-bullseye, rc-apache-bullseye, 10.0.0-rc3-apache, 10.0-rc-apache, rc-apache, 10.0.0-rc3, 10.0-rc, rc
+Tags: 10.0.0-php8.2-apache-bullseye, 10.0-php8.2-apache-bullseye, 10-php8.2-apache-bullseye, php8.2-apache-bullseye, 10.0.0-php8.2-apache, 10.0-php8.2-apache, 10-php8.2-apache, php8.2-apache, 10.0.0-php8.2, 10.0-php8.2, 10-php8.2, php8.2, 10.0.0-apache-bullseye, 10.0-apache-bullseye, 10-apache-bullseye, apache-bullseye, 10.0.0-apache, 10.0-apache, 10-apache, apache, 10.0.0, 10.0, 10, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 19559d62d44c5b3d7fe69a957e6154da08300fd9
-Directory: 10.0-rc/php8.2/apache-bullseye
+GitCommit: 85787d8d84242e96e9976f68810025444ae0db4c
+Directory: 10.0/php8.2/apache-bullseye
 
-Tags: 10.0.0-rc3-php8.2-fpm-bullseye, 10.0-rc-php8.2-fpm-bullseye, rc-php8.2-fpm-bullseye, 10.0.0-rc3-php8.2-fpm, 10.0-rc-php8.2-fpm, rc-php8.2-fpm, 10.0.0-rc3-fpm-bullseye, 10.0-rc-fpm-bullseye, rc-fpm-bullseye, 10.0.0-rc3-fpm, 10.0-rc-fpm, rc-fpm
+Tags: 10.0.0-php8.2-fpm-bullseye, 10.0-php8.2-fpm-bullseye, 10-php8.2-fpm-bullseye, php8.2-fpm-bullseye, 10.0.0-php8.2-fpm, 10.0-php8.2-fpm, 10-php8.2-fpm, php8.2-fpm, 10.0.0-fpm-bullseye, 10.0-fpm-bullseye, 10-fpm-bullseye, fpm-bullseye, 10.0.0-fpm, 10.0-fpm, 10-fpm, fpm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 19559d62d44c5b3d7fe69a957e6154da08300fd9
-Directory: 10.0-rc/php8.2/fpm-bullseye
+GitCommit: 85787d8d84242e96e9976f68810025444ae0db4c
+Directory: 10.0/php8.2/fpm-bullseye
 
-Tags: 10.0.0-rc3-php8.2-apache-buster, 10.0-rc-php8.2-apache-buster, rc-php8.2-apache-buster, 10.0.0-rc3-apache-buster, 10.0-rc-apache-buster, rc-apache-buster
+Tags: 10.0.0-php8.2-apache-buster, 10.0-php8.2-apache-buster, 10-php8.2-apache-buster, php8.2-apache-buster, 10.0.0-apache-buster, 10.0-apache-buster, 10-apache-buster, apache-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 19559d62d44c5b3d7fe69a957e6154da08300fd9
-Directory: 10.0-rc/php8.2/apache-buster
+GitCommit: 85787d8d84242e96e9976f68810025444ae0db4c
+Directory: 10.0/php8.2/apache-buster
 
-Tags: 10.0.0-rc3-php8.2-fpm-buster, 10.0-rc-php8.2-fpm-buster, rc-php8.2-fpm-buster, 10.0.0-rc3-fpm-buster, 10.0-rc-fpm-buster, rc-fpm-buster
+Tags: 10.0.0-php8.2-fpm-buster, 10.0-php8.2-fpm-buster, 10-php8.2-fpm-buster, php8.2-fpm-buster, 10.0.0-fpm-buster, 10.0-fpm-buster, 10-fpm-buster, fpm-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 19559d62d44c5b3d7fe69a957e6154da08300fd9
-Directory: 10.0-rc/php8.2/fpm-buster
+GitCommit: 85787d8d84242e96e9976f68810025444ae0db4c
+Directory: 10.0/php8.2/fpm-buster
 
-Tags: 10.0.0-rc3-php8.2-fpm-alpine3.17, 10.0-rc-php8.2-fpm-alpine3.17, rc-php8.2-fpm-alpine3.17, 10.0.0-rc3-php8.2-fpm-alpine, 10.0-rc-php8.2-fpm-alpine, rc-php8.2-fpm-alpine, 10.0.0-rc3-fpm-alpine3.17, 10.0-rc-fpm-alpine3.17, rc-fpm-alpine3.17, 10.0.0-rc3-fpm-alpine, 10.0-rc-fpm-alpine, rc-fpm-alpine
+Tags: 10.0.0-php8.2-fpm-alpine3.17, 10.0-php8.2-fpm-alpine3.17, 10-php8.2-fpm-alpine3.17, php8.2-fpm-alpine3.17, 10.0.0-php8.2-fpm-alpine, 10.0-php8.2-fpm-alpine, 10-php8.2-fpm-alpine, php8.2-fpm-alpine, 10.0.0-fpm-alpine3.17, 10.0-fpm-alpine3.17, 10-fpm-alpine3.17, fpm-alpine3.17, 10.0.0-fpm-alpine, 10.0-fpm-alpine, 10-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 19559d62d44c5b3d7fe69a957e6154da08300fd9
-Directory: 10.0-rc/php8.2/fpm-alpine3.17
+GitCommit: 85787d8d84242e96e9976f68810025444ae0db4c
+Directory: 10.0/php8.2/fpm-alpine3.17
 
-Tags: 10.0.0-rc3-php8.2-fpm-alpine3.16, 10.0-rc-php8.2-fpm-alpine3.16, rc-php8.2-fpm-alpine3.16, 10.0.0-rc3-fpm-alpine3.16, 10.0-rc-fpm-alpine3.16, rc-fpm-alpine3.16
+Tags: 10.0.0-php8.2-fpm-alpine3.16, 10.0-php8.2-fpm-alpine3.16, 10-php8.2-fpm-alpine3.16, php8.2-fpm-alpine3.16, 10.0.0-fpm-alpine3.16, 10.0-fpm-alpine3.16, 10-fpm-alpine3.16, fpm-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 19559d62d44c5b3d7fe69a957e6154da08300fd9
-Directory: 10.0-rc/php8.2/fpm-alpine3.16
+GitCommit: 85787d8d84242e96e9976f68810025444ae0db4c
+Directory: 10.0/php8.2/fpm-alpine3.16
 
-Tags: 10.0.0-rc3-php8.1-apache-bullseye, 10.0-rc-php8.1-apache-bullseye, rc-php8.1-apache-bullseye, 10.0.0-rc3-php8.1-apache, 10.0-rc-php8.1-apache, rc-php8.1-apache, 10.0.0-rc3-php8.1, 10.0-rc-php8.1, rc-php8.1
+Tags: 10.0.0-php8.1-apache-bullseye, 10.0-php8.1-apache-bullseye, 10-php8.1-apache-bullseye, php8.1-apache-bullseye, 10.0.0-php8.1-apache, 10.0-php8.1-apache, 10-php8.1-apache, php8.1-apache, 10.0.0-php8.1, 10.0-php8.1, 10-php8.1, php8.1
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e91a9b1064829768c8df958b143350b6865755e
-Directory: 10.0-rc/php8.1/apache-bullseye
+GitCommit: 85787d8d84242e96e9976f68810025444ae0db4c
+Directory: 10.0/php8.1/apache-bullseye
 
-Tags: 10.0.0-rc3-php8.1-fpm-bullseye, 10.0-rc-php8.1-fpm-bullseye, rc-php8.1-fpm-bullseye, 10.0.0-rc3-php8.1-fpm, 10.0-rc-php8.1-fpm, rc-php8.1-fpm
+Tags: 10.0.0-php8.1-fpm-bullseye, 10.0-php8.1-fpm-bullseye, 10-php8.1-fpm-bullseye, php8.1-fpm-bullseye, 10.0.0-php8.1-fpm, 10.0-php8.1-fpm, 10-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e91a9b1064829768c8df958b143350b6865755e
-Directory: 10.0-rc/php8.1/fpm-bullseye
+GitCommit: 85787d8d84242e96e9976f68810025444ae0db4c
+Directory: 10.0/php8.1/fpm-bullseye
 
-Tags: 10.0.0-rc3-php8.1-apache-buster, 10.0-rc-php8.1-apache-buster, rc-php8.1-apache-buster
+Tags: 10.0.0-php8.1-apache-buster, 10.0-php8.1-apache-buster, 10-php8.1-apache-buster, php8.1-apache-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 4e91a9b1064829768c8df958b143350b6865755e
-Directory: 10.0-rc/php8.1/apache-buster
+GitCommit: 85787d8d84242e96e9976f68810025444ae0db4c
+Directory: 10.0/php8.1/apache-buster
 
-Tags: 10.0.0-rc3-php8.1-fpm-buster, 10.0-rc-php8.1-fpm-buster, rc-php8.1-fpm-buster
+Tags: 10.0.0-php8.1-fpm-buster, 10.0-php8.1-fpm-buster, 10-php8.1-fpm-buster, php8.1-fpm-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 4e91a9b1064829768c8df958b143350b6865755e
-Directory: 10.0-rc/php8.1/fpm-buster
+GitCommit: 85787d8d84242e96e9976f68810025444ae0db4c
+Directory: 10.0/php8.1/fpm-buster
 
-Tags: 10.0.0-rc3-php8.1-fpm-alpine3.17, 10.0-rc-php8.1-fpm-alpine3.17, rc-php8.1-fpm-alpine3.17, 10.0.0-rc3-php8.1-fpm-alpine, 10.0-rc-php8.1-fpm-alpine, rc-php8.1-fpm-alpine
+Tags: 10.0.0-php8.1-fpm-alpine3.17, 10.0-php8.1-fpm-alpine3.17, 10-php8.1-fpm-alpine3.17, php8.1-fpm-alpine3.17, 10.0.0-php8.1-fpm-alpine, 10.0-php8.1-fpm-alpine, 10-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e91a9b1064829768c8df958b143350b6865755e
-Directory: 10.0-rc/php8.1/fpm-alpine3.17
+GitCommit: 85787d8d84242e96e9976f68810025444ae0db4c
+Directory: 10.0/php8.1/fpm-alpine3.17
 
-Tags: 10.0.0-rc3-php8.1-fpm-alpine3.16, 10.0-rc-php8.1-fpm-alpine3.16, rc-php8.1-fpm-alpine3.16
+Tags: 10.0.0-php8.1-fpm-alpine3.16, 10.0-php8.1-fpm-alpine3.16, 10-php8.1-fpm-alpine3.16, php8.1-fpm-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e91a9b1064829768c8df958b143350b6865755e
-Directory: 10.0-rc/php8.1/fpm-alpine3.16
+GitCommit: 85787d8d84242e96e9976f68810025444ae0db4c
+Directory: 10.0/php8.1/fpm-alpine3.16
 
-Tags: 9.5.0-php8.1-apache-bullseye, 9.5-php8.1-apache-bullseye, 9-php8.1-apache-bullseye, php8.1-apache-bullseye, 9.5.0-php8.1-apache, 9.5-php8.1-apache, 9-php8.1-apache, php8.1-apache, 9.5.0-php8.1, 9.5-php8.1, 9-php8.1, php8.1, 9.5.0-apache-bullseye, 9.5-apache-bullseye, 9-apache-bullseye, apache-bullseye, 9.5.0-apache, 9.5-apache, 9-apache, apache, 9.5.0, 9.5, 9, latest
+Tags: 9.5.0-php8.1-apache-bullseye, 9.5-php8.1-apache-bullseye, 9-php8.1-apache-bullseye, 9.5.0-php8.1-apache, 9.5-php8.1-apache, 9-php8.1-apache, 9.5.0-php8.1, 9.5-php8.1, 9-php8.1, 9.5.0-apache-bullseye, 9.5-apache-bullseye, 9-apache-bullseye, 9.5.0-apache, 9.5-apache, 9-apache, 9.5.0, 9.5, 9
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 19559d62d44c5b3d7fe69a957e6154da08300fd9
 Directory: 9.5/php8.1/apache-bullseye
 
-Tags: 9.5.0-php8.1-fpm-bullseye, 9.5-php8.1-fpm-bullseye, 9-php8.1-fpm-bullseye, php8.1-fpm-bullseye, 9.5.0-php8.1-fpm, 9.5-php8.1-fpm, 9-php8.1-fpm, php8.1-fpm, 9.5.0-fpm-bullseye, 9.5-fpm-bullseye, 9-fpm-bullseye, fpm-bullseye, 9.5.0-fpm, 9.5-fpm, 9-fpm, fpm
+Tags: 9.5.0-php8.1-fpm-bullseye, 9.5-php8.1-fpm-bullseye, 9-php8.1-fpm-bullseye, 9.5.0-php8.1-fpm, 9.5-php8.1-fpm, 9-php8.1-fpm, 9.5.0-fpm-bullseye, 9.5-fpm-bullseye, 9-fpm-bullseye, 9.5.0-fpm, 9.5-fpm, 9-fpm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 19559d62d44c5b3d7fe69a957e6154da08300fd9
 Directory: 9.5/php8.1/fpm-bullseye
 
-Tags: 9.5.0-php8.1-apache-buster, 9.5-php8.1-apache-buster, 9-php8.1-apache-buster, php8.1-apache-buster, 9.5.0-apache-buster, 9.5-apache-buster, 9-apache-buster, apache-buster
+Tags: 9.5.0-php8.1-apache-buster, 9.5-php8.1-apache-buster, 9-php8.1-apache-buster, 9.5.0-apache-buster, 9.5-apache-buster, 9-apache-buster
 Architectures: amd64, arm32v7, arm64v8, i386
 GitCommit: 19559d62d44c5b3d7fe69a957e6154da08300fd9
 Directory: 9.5/php8.1/apache-buster
 
-Tags: 9.5.0-php8.1-fpm-buster, 9.5-php8.1-fpm-buster, 9-php8.1-fpm-buster, php8.1-fpm-buster, 9.5.0-fpm-buster, 9.5-fpm-buster, 9-fpm-buster, fpm-buster
+Tags: 9.5.0-php8.1-fpm-buster, 9.5-php8.1-fpm-buster, 9-php8.1-fpm-buster, 9.5.0-fpm-buster, 9.5-fpm-buster, 9-fpm-buster
 Architectures: amd64, arm32v7, arm64v8, i386
 GitCommit: 19559d62d44c5b3d7fe69a957e6154da08300fd9
 Directory: 9.5/php8.1/fpm-buster
 
-Tags: 9.5.0-php8.1-fpm-alpine3.17, 9.5-php8.1-fpm-alpine3.17, 9-php8.1-fpm-alpine3.17, php8.1-fpm-alpine3.17, 9.5.0-php8.1-fpm-alpine, 9.5-php8.1-fpm-alpine, 9-php8.1-fpm-alpine, php8.1-fpm-alpine, 9.5.0-fpm-alpine3.17, 9.5-fpm-alpine3.17, 9-fpm-alpine3.17, fpm-alpine3.17, 9.5.0-fpm-alpine, 9.5-fpm-alpine, 9-fpm-alpine, fpm-alpine
+Tags: 9.5.0-php8.1-fpm-alpine3.17, 9.5-php8.1-fpm-alpine3.17, 9-php8.1-fpm-alpine3.17, 9.5.0-php8.1-fpm-alpine, 9.5-php8.1-fpm-alpine, 9-php8.1-fpm-alpine, 9.5.0-fpm-alpine3.17, 9.5-fpm-alpine3.17, 9-fpm-alpine3.17, 9.5.0-fpm-alpine, 9.5-fpm-alpine, 9-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 19559d62d44c5b3d7fe69a957e6154da08300fd9
 Directory: 9.5/php8.1/fpm-alpine3.17
 
-Tags: 9.5.0-php8.1-fpm-alpine3.16, 9.5-php8.1-fpm-alpine3.16, 9-php8.1-fpm-alpine3.16, php8.1-fpm-alpine3.16, 9.5.0-fpm-alpine3.16, 9.5-fpm-alpine3.16, 9-fpm-alpine3.16, fpm-alpine3.16
+Tags: 9.5.0-php8.1-fpm-alpine3.16, 9.5-php8.1-fpm-alpine3.16, 9-php8.1-fpm-alpine3.16, 9.5.0-fpm-alpine3.16, 9.5-fpm-alpine3.16, 9-fpm-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 19559d62d44c5b3d7fe69a957e6154da08300fd9
 Directory: 9.5/php8.1/fpm-alpine3.16
 
-Tags: 9.5.0-php8.0-apache-bullseye, 9.5-php8.0-apache-bullseye, 9-php8.0-apache-bullseye, php8.0-apache-bullseye, 9.5.0-php8.0-apache, 9.5-php8.0-apache, 9-php8.0-apache, php8.0-apache, 9.5.0-php8.0, 9.5-php8.0, 9-php8.0, php8.0
+Tags: 9.5.0-php8.0-apache-bullseye, 9.5-php8.0-apache-bullseye, 9-php8.0-apache-bullseye, 9.5.0-php8.0-apache, 9.5-php8.0-apache, 9-php8.0-apache, 9.5.0-php8.0, 9.5-php8.0, 9-php8.0
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 19559d62d44c5b3d7fe69a957e6154da08300fd9
 Directory: 9.5/php8.0/apache-bullseye
 
-Tags: 9.5.0-php8.0-fpm-bullseye, 9.5-php8.0-fpm-bullseye, 9-php8.0-fpm-bullseye, php8.0-fpm-bullseye, 9.5.0-php8.0-fpm, 9.5-php8.0-fpm, 9-php8.0-fpm, php8.0-fpm
+Tags: 9.5.0-php8.0-fpm-bullseye, 9.5-php8.0-fpm-bullseye, 9-php8.0-fpm-bullseye, 9.5.0-php8.0-fpm, 9.5-php8.0-fpm, 9-php8.0-fpm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 19559d62d44c5b3d7fe69a957e6154da08300fd9
 Directory: 9.5/php8.0/fpm-bullseye
 
-Tags: 9.5.0-php8.0-apache-buster, 9.5-php8.0-apache-buster, 9-php8.0-apache-buster, php8.0-apache-buster
+Tags: 9.5.0-php8.0-apache-buster, 9.5-php8.0-apache-buster, 9-php8.0-apache-buster
 Architectures: amd64, arm32v7, arm64v8, i386
 GitCommit: 19559d62d44c5b3d7fe69a957e6154da08300fd9
 Directory: 9.5/php8.0/apache-buster
 
-Tags: 9.5.0-php8.0-fpm-buster, 9.5-php8.0-fpm-buster, 9-php8.0-fpm-buster, php8.0-fpm-buster
+Tags: 9.5.0-php8.0-fpm-buster, 9.5-php8.0-fpm-buster, 9-php8.0-fpm-buster
 Architectures: amd64, arm32v7, arm64v8, i386
 GitCommit: 19559d62d44c5b3d7fe69a957e6154da08300fd9
 Directory: 9.5/php8.0/fpm-buster
 
-Tags: 9.5.0-php8.0-fpm-alpine3.16, 9.5-php8.0-fpm-alpine3.16, 9-php8.0-fpm-alpine3.16, php8.0-fpm-alpine3.16
+Tags: 9.5.0-php8.0-fpm-alpine3.16, 9.5-php8.0-fpm-alpine3.16, 9-php8.0-fpm-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 19559d62d44c5b3d7fe69a957e6154da08300fd9
 Directory: 9.5/php8.0/fpm-alpine3.16
```