### PR TITLE
Drop deprecated opcache.fast_shutdown config

### DIFF
--- a/10.0/php8.1/apache-bullseye/Dockerfile
+++ b/10.0/php8.1/apache-bullseye/Dockerfile
@@ -61,7 +61,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/10.0/php8.1/apache-buster/Dockerfile
+++ b/10.0/php8.1/apache-buster/Dockerfile
@@ -61,7 +61,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/10.0/php8.1/fpm-alpine3.16/Dockerfile
+++ b/10.0/php8.1/fpm-alpine3.16/Dockerfile
@@ -51,7 +51,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/10.0/php8.1/fpm-alpine3.17/Dockerfile
+++ b/10.0/php8.1/fpm-alpine3.17/Dockerfile
@@ -51,7 +51,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/10.0/php8.1/fpm-bullseye/Dockerfile
+++ b/10.0/php8.1/fpm-bullseye/Dockerfile
@@ -61,7 +61,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/10.0/php8.1/fpm-buster/Dockerfile
+++ b/10.0/php8.1/fpm-buster/Dockerfile
@@ -61,7 +61,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/10.0/php8.2/apache-bullseye/Dockerfile
+++ b/10.0/php8.2/apache-bullseye/Dockerfile
@@ -61,7 +61,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/10.0/php8.2/apache-buster/Dockerfile
+++ b/10.0/php8.2/apache-buster/Dockerfile
@@ -61,7 +61,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/10.0/php8.2/fpm-alpine3.16/Dockerfile
+++ b/10.0/php8.2/fpm-alpine3.16/Dockerfile
@@ -51,7 +51,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/10.0/php8.2/fpm-alpine3.17/Dockerfile
+++ b/10.0/php8.2/fpm-alpine3.17/Dockerfile
@@ -51,7 +51,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/10.0/php8.2/fpm-bullseye/Dockerfile
+++ b/10.0/php8.2/fpm-bullseye/Dockerfile
@@ -61,7 +61,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/10.0/php8.2/fpm-buster/Dockerfile
+++ b/10.0/php8.2/fpm-buster/Dockerfile
@@ -61,7 +61,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/7/php8.0/apache-bullseye/Dockerfile
+++ b/7/php8.0/apache-bullseye/Dockerfile
@@ -61,7 +61,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 # https://www.drupal.org/node/3060/release

--- a/7/php8.0/apache-buster/Dockerfile
+++ b/7/php8.0/apache-buster/Dockerfile
@@ -61,7 +61,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 # https://www.drupal.org/node/3060/release

--- a/7/php8.0/fpm-alpine3.16/Dockerfile
+++ b/7/php8.0/fpm-alpine3.16/Dockerfile
@@ -51,7 +51,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 # https://www.drupal.org/node/3060/release

--- a/7/php8.0/fpm-bullseye/Dockerfile
+++ b/7/php8.0/fpm-bullseye/Dockerfile
@@ -61,7 +61,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 # https://www.drupal.org/node/3060/release

--- a/7/php8.0/fpm-buster/Dockerfile
+++ b/7/php8.0/fpm-buster/Dockerfile
@@ -61,7 +61,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 # https://www.drupal.org/node/3060/release

--- a/9.4/php8.0/apache-bullseye/Dockerfile
+++ b/9.4/php8.0/apache-bullseye/Dockerfile
@@ -61,7 +61,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/9.4/php8.0/apache-buster/Dockerfile
+++ b/9.4/php8.0/apache-buster/Dockerfile
@@ -61,7 +61,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/9.4/php8.0/fpm-alpine3.16/Dockerfile
+++ b/9.4/php8.0/fpm-alpine3.16/Dockerfile
@@ -51,7 +51,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/9.4/php8.0/fpm-bullseye/Dockerfile
+++ b/9.4/php8.0/fpm-bullseye/Dockerfile
@@ -61,7 +61,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/9.4/php8.0/fpm-buster/Dockerfile
+++ b/9.4/php8.0/fpm-buster/Dockerfile
@@ -61,7 +61,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/9.4/php8.1/apache-bullseye/Dockerfile
+++ b/9.4/php8.1/apache-bullseye/Dockerfile
@@ -61,7 +61,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/9.4/php8.1/apache-buster/Dockerfile
+++ b/9.4/php8.1/apache-buster/Dockerfile
@@ -61,7 +61,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/9.4/php8.1/fpm-alpine3.16/Dockerfile
+++ b/9.4/php8.1/fpm-alpine3.16/Dockerfile
@@ -51,7 +51,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/9.4/php8.1/fpm-alpine3.17/Dockerfile
+++ b/9.4/php8.1/fpm-alpine3.17/Dockerfile
@@ -51,7 +51,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/9.4/php8.1/fpm-bullseye/Dockerfile
+++ b/9.4/php8.1/fpm-bullseye/Dockerfile
@@ -61,7 +61,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/9.4/php8.1/fpm-buster/Dockerfile
+++ b/9.4/php8.1/fpm-buster/Dockerfile
@@ -61,7 +61,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/9.5/php8.0/apache-bullseye/Dockerfile
+++ b/9.5/php8.0/apache-bullseye/Dockerfile
@@ -61,7 +61,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/9.5/php8.0/apache-buster/Dockerfile
+++ b/9.5/php8.0/apache-buster/Dockerfile
@@ -61,7 +61,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/9.5/php8.0/fpm-alpine3.16/Dockerfile
+++ b/9.5/php8.0/fpm-alpine3.16/Dockerfile
@@ -51,7 +51,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/9.5/php8.0/fpm-bullseye/Dockerfile
+++ b/9.5/php8.0/fpm-bullseye/Dockerfile
@@ -61,7 +61,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/9.5/php8.0/fpm-buster/Dockerfile
+++ b/9.5/php8.0/fpm-buster/Dockerfile
@@ -61,7 +61,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/9.5/php8.1/apache-bullseye/Dockerfile
+++ b/9.5/php8.1/apache-bullseye/Dockerfile
@@ -61,7 +61,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/9.5/php8.1/apache-buster/Dockerfile
+++ b/9.5/php8.1/apache-buster/Dockerfile
@@ -61,7 +61,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/9.5/php8.1/fpm-alpine3.16/Dockerfile
+++ b/9.5/php8.1/fpm-alpine3.16/Dockerfile
@@ -51,7 +51,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/9.5/php8.1/fpm-alpine3.17/Dockerfile
+++ b/9.5/php8.1/fpm-alpine3.17/Dockerfile
@@ -51,7 +51,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/9.5/php8.1/fpm-bullseye/Dockerfile
+++ b/9.5/php8.1/fpm-bullseye/Dockerfile
@@ -61,7 +61,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/9.5/php8.1/fpm-buster/Dockerfile
+++ b/9.5/php8.1/fpm-buster/Dockerfile
@@ -61,7 +61,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -82,7 +82,6 @@ RUN { \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \
 		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 {{ if env.version | startswith("7") then "" else ( -}}


### PR DESCRIPTION
>This directive has been removed in PHP 7.2.0. A variant of the fast shutdown sequence has been integrated into PHP and will be automatically used if possible.

Thanks @jnoordsij for noticing the deprecated option and in getting it updated in PHP docs (https://github.com/php/doc-en/issues/2172)!

Fixes https://github.com/docker-library/drupal/issues/236