### PR TITLE
Enable Apache mod_expires

### DIFF
--- a/10.0/php8.1/apache-bookworm/Dockerfile
+++ b/10.0/php8.1/apache-bookworm/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.1-apache-bookworm
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/10.0/php8.1/apache-bullseye/Dockerfile
+++ b/10.0/php8.1/apache-bullseye/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.1-apache-bullseye
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/10.0/php8.1/fpm-bookworm/Dockerfile
+++ b/10.0/php8.1/fpm-bookworm/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.1-fpm-bookworm
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/10.0/php8.1/fpm-bullseye/Dockerfile
+++ b/10.0/php8.1/fpm-bullseye/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.1-fpm-bullseye
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/10.0/php8.2/apache-bookworm/Dockerfile
+++ b/10.0/php8.2/apache-bookworm/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.2-apache-bookworm
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/10.0/php8.2/apache-bullseye/Dockerfile
+++ b/10.0/php8.2/apache-bullseye/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.2-apache-bullseye
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/10.0/php8.2/fpm-bookworm/Dockerfile
+++ b/10.0/php8.2/fpm-bookworm/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.2-fpm-bookworm
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/10.0/php8.2/fpm-bullseye/Dockerfile
+++ b/10.0/php8.2/fpm-bullseye/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.2-fpm-bullseye
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/10.1/php8.1/apache-bookworm/Dockerfile
+++ b/10.1/php8.1/apache-bookworm/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.1-apache-bookworm
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/10.1/php8.1/apache-bullseye/Dockerfile
+++ b/10.1/php8.1/apache-bullseye/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.1-apache-bullseye
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/10.1/php8.1/fpm-bookworm/Dockerfile
+++ b/10.1/php8.1/fpm-bookworm/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.1-fpm-bookworm
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/10.1/php8.1/fpm-bullseye/Dockerfile
+++ b/10.1/php8.1/fpm-bullseye/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.1-fpm-bullseye
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/10.1/php8.2/apache-bookworm/Dockerfile
+++ b/10.1/php8.2/apache-bookworm/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.2-apache-bookworm
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/10.1/php8.2/apache-bullseye/Dockerfile
+++ b/10.1/php8.2/apache-bullseye/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.2-apache-bullseye
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/10.1/php8.2/fpm-bookworm/Dockerfile
+++ b/10.1/php8.2/fpm-bookworm/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.2-fpm-bookworm
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/10.1/php8.2/fpm-bullseye/Dockerfile
+++ b/10.1/php8.2/fpm-bullseye/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.2-fpm-bullseye
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/7/php8.1/apache-bookworm/Dockerfile
+++ b/7/php8.1/apache-bookworm/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.1-apache-bookworm
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/7/php8.1/apache-bullseye/Dockerfile
+++ b/7/php8.1/apache-bullseye/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.1-apache-bullseye
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/7/php8.1/fpm-bookworm/Dockerfile
+++ b/7/php8.1/fpm-bookworm/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.1-fpm-bookworm
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/7/php8.1/fpm-bullseye/Dockerfile
+++ b/7/php8.1/fpm-bullseye/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.1-fpm-bullseye
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/7/php8.2/apache-bookworm/Dockerfile
+++ b/7/php8.2/apache-bookworm/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.2-apache-bookworm
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/7/php8.2/apache-bullseye/Dockerfile
+++ b/7/php8.2/apache-bullseye/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.2-apache-bullseye
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/7/php8.2/fpm-bookworm/Dockerfile
+++ b/7/php8.2/fpm-bookworm/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.2-fpm-bookworm
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/7/php8.2/fpm-bullseye/Dockerfile
+++ b/7/php8.2/fpm-bullseye/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.2-fpm-bullseye
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/9.5/php8.1/apache-bookworm/Dockerfile
+++ b/9.5/php8.1/apache-bookworm/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.1-apache-bookworm
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/9.5/php8.1/apache-bullseye/Dockerfile
+++ b/9.5/php8.1/apache-bullseye/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.1-apache-bullseye
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/9.5/php8.1/fpm-bookworm/Dockerfile
+++ b/9.5/php8.1/fpm-bookworm/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.1-fpm-bookworm
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/9.5/php8.1/fpm-bullseye/Dockerfile
+++ b/9.5/php8.1/fpm-bullseye/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.1-fpm-bullseye
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/9.5/php8.2/apache-bookworm/Dockerfile
+++ b/9.5/php8.2/apache-bookworm/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.2-apache-bookworm
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/9.5/php8.2/apache-bullseye/Dockerfile
+++ b/9.5/php8.2/apache-bullseye/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.2-apache-bullseye
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/9.5/php8.2/fpm-bookworm/Dockerfile
+++ b/9.5/php8.2/fpm-bookworm/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.2-fpm-bookworm
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/9.5/php8.2/fpm-bullseye/Dockerfile
+++ b/9.5/php8.2/fpm-bullseye/Dockerfile
@@ -11,7 +11,8 @@ FROM php:8.2-fpm-bullseye
 RUN set -eux; \
 	\
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -20,7 +20,8 @@ RUN set -eux; \
 		postgresql-dev \
 {{ ) else ( -}}
 	if command -v a2enmod; then \
-		a2enmod rewrite; \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
 	fi; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \


### PR DESCRIPTION
It will allow Drupal to set cache headers https://github.com/drupal/drupal/blob/10.0.x/.htaccess#L34.

The expires module is enabled the same in the Wordpress Dockerfile https://github.com/docker-library/wordpress/blob/master/Dockerfile.template#L161