### PR TITLE
Fixes when building with buildkit

### DIFF
--- a/10.1/php8.1/apache-bookworm/Dockerfile
+++ b/10.1/php8.1/apache-bookworm/Dockerfile
@@ -69,6 +69,13 @@ COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 # 2024-01-17: https://www.drupal.org/project/drupal/releases/10.1.8
 ENV DRUPAL_VERSION 10.1.8
 
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
 WORKDIR /opt/drupal
 RUN set -eux; \
 	export COMPOSER_HOME="$(mktemp -d)"; \

--- a/10.1/php8.1/apache-bullseye/Dockerfile
+++ b/10.1/php8.1/apache-bullseye/Dockerfile
@@ -69,6 +69,13 @@ COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 # 2024-01-17: https://www.drupal.org/project/drupal/releases/10.1.8
 ENV DRUPAL_VERSION 10.1.8
 
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
 WORKDIR /opt/drupal
 RUN set -eux; \
 	export COMPOSER_HOME="$(mktemp -d)"; \

--- a/10.1/php8.1/fpm-alpine3.18/Dockerfile
+++ b/10.1/php8.1/fpm-alpine3.18/Dockerfile
@@ -58,6 +58,13 @@ COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 # 2024-01-17: https://www.drupal.org/project/drupal/releases/10.1.8
 ENV DRUPAL_VERSION 10.1.8
 
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
 WORKDIR /opt/drupal
 RUN set -eux; \
 	export COMPOSER_HOME="$(mktemp -d)"; \

--- a/10.1/php8.1/fpm-alpine3.19/Dockerfile
+++ b/10.1/php8.1/fpm-alpine3.19/Dockerfile
@@ -58,6 +58,13 @@ COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 # 2024-01-17: https://www.drupal.org/project/drupal/releases/10.1.8
 ENV DRUPAL_VERSION 10.1.8
 
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
 WORKDIR /opt/drupal
 RUN set -eux; \
 	export COMPOSER_HOME="$(mktemp -d)"; \

--- a/10.1/php8.1/fpm-bookworm/Dockerfile
+++ b/10.1/php8.1/fpm-bookworm/Dockerfile
@@ -69,6 +69,13 @@ COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 # 2024-01-17: https://www.drupal.org/project/drupal/releases/10.1.8
 ENV DRUPAL_VERSION 10.1.8
 
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
 WORKDIR /opt/drupal
 RUN set -eux; \
 	export COMPOSER_HOME="$(mktemp -d)"; \

--- a/10.1/php8.1/fpm-bullseye/Dockerfile
+++ b/10.1/php8.1/fpm-bullseye/Dockerfile
@@ -69,6 +69,13 @@ COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 # 2024-01-17: https://www.drupal.org/project/drupal/releases/10.1.8
 ENV DRUPAL_VERSION 10.1.8
 
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
 WORKDIR /opt/drupal
 RUN set -eux; \
 	export COMPOSER_HOME="$(mktemp -d)"; \

--- a/10.1/php8.2/apache-bookworm/Dockerfile
+++ b/10.1/php8.2/apache-bookworm/Dockerfile
@@ -69,6 +69,13 @@ COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 # 2024-01-17: https://www.drupal.org/project/drupal/releases/10.1.8
 ENV DRUPAL_VERSION 10.1.8
 
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
 WORKDIR /opt/drupal
 RUN set -eux; \
 	export COMPOSER_HOME="$(mktemp -d)"; \

--- a/10.1/php8.2/apache-bullseye/Dockerfile
+++ b/10.1/php8.2/apache-bullseye/Dockerfile
@@ -69,6 +69,13 @@ COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 # 2024-01-17: https://www.drupal.org/project/drupal/releases/10.1.8
 ENV DRUPAL_VERSION 10.1.8
 
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
 WORKDIR /opt/drupal
 RUN set -eux; \
 	export COMPOSER_HOME="$(mktemp -d)"; \

--- a/10.1/php8.2/fpm-alpine3.18/Dockerfile
+++ b/10.1/php8.2/fpm-alpine3.18/Dockerfile
@@ -58,6 +58,13 @@ COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 # 2024-01-17: https://www.drupal.org/project/drupal/releases/10.1.8
 ENV DRUPAL_VERSION 10.1.8
 
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
 WORKDIR /opt/drupal
 RUN set -eux; \
 	export COMPOSER_HOME="$(mktemp -d)"; \

--- a/10.1/php8.2/fpm-alpine3.19/Dockerfile
+++ b/10.1/php8.2/fpm-alpine3.19/Dockerfile
@@ -58,6 +58,13 @@ COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 # 2024-01-17: https://www.drupal.org/project/drupal/releases/10.1.8
 ENV DRUPAL_VERSION 10.1.8
 
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
 WORKDIR /opt/drupal
 RUN set -eux; \
 	export COMPOSER_HOME="$(mktemp -d)"; \

--- a/10.1/php8.2/fpm-bookworm/Dockerfile
+++ b/10.1/php8.2/fpm-bookworm/Dockerfile
@@ -69,6 +69,13 @@ COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 # 2024-01-17: https://www.drupal.org/project/drupal/releases/10.1.8
 ENV DRUPAL_VERSION 10.1.8
 
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
 WORKDIR /opt/drupal
 RUN set -eux; \
 	export COMPOSER_HOME="$(mktemp -d)"; \

--- a/10.1/php8.2/fpm-bullseye/Dockerfile
+++ b/10.1/php8.2/fpm-bullseye/Dockerfile
@@ -69,6 +69,13 @@ COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 # 2024-01-17: https://www.drupal.org/project/drupal/releases/10.1.8
 ENV DRUPAL_VERSION 10.1.8
 
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
 WORKDIR /opt/drupal
 RUN set -eux; \
 	export COMPOSER_HOME="$(mktemp -d)"; \

--- a/10.2/php8.2/apache-bookworm/Dockerfile
+++ b/10.2/php8.2/apache-bookworm/Dockerfile
@@ -69,6 +69,13 @@ COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 # 2024-03-06: https://www.drupal.org/project/drupal/releases/10.2.4
 ENV DRUPAL_VERSION 10.2.4
 
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
 WORKDIR /opt/drupal
 RUN set -eux; \
 	export COMPOSER_HOME="$(mktemp -d)"; \

--- a/10.2/php8.2/apache-bullseye/Dockerfile
+++ b/10.2/php8.2/apache-bullseye/Dockerfile
@@ -69,6 +69,13 @@ COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 # 2024-03-06: https://www.drupal.org/project/drupal/releases/10.2.4
 ENV DRUPAL_VERSION 10.2.4
 
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
 WORKDIR /opt/drupal
 RUN set -eux; \
 	export COMPOSER_HOME="$(mktemp -d)"; \

--- a/10.2/php8.2/fpm-alpine3.18/Dockerfile
+++ b/10.2/php8.2/fpm-alpine3.18/Dockerfile
@@ -58,6 +58,13 @@ COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 # 2024-03-06: https://www.drupal.org/project/drupal/releases/10.2.4
 ENV DRUPAL_VERSION 10.2.4
 
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
 WORKDIR /opt/drupal
 RUN set -eux; \
 	export COMPOSER_HOME="$(mktemp -d)"; \

--- a/10.2/php8.2/fpm-alpine3.19/Dockerfile
+++ b/10.2/php8.2/fpm-alpine3.19/Dockerfile
@@ -58,6 +58,13 @@ COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 # 2024-03-06: https://www.drupal.org/project/drupal/releases/10.2.4
 ENV DRUPAL_VERSION 10.2.4
 
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
 WORKDIR /opt/drupal
 RUN set -eux; \
 	export COMPOSER_HOME="$(mktemp -d)"; \

--- a/10.2/php8.2/fpm-bookworm/Dockerfile
+++ b/10.2/php8.2/fpm-bookworm/Dockerfile
@@ -69,6 +69,13 @@ COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 # 2024-03-06: https://www.drupal.org/project/drupal/releases/10.2.4
 ENV DRUPAL_VERSION 10.2.4
 
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
 WORKDIR /opt/drupal
 RUN set -eux; \
 	export COMPOSER_HOME="$(mktemp -d)"; \

--- a/10.2/php8.2/fpm-bullseye/Dockerfile
+++ b/10.2/php8.2/fpm-bullseye/Dockerfile
@@ -69,6 +69,13 @@ COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 # 2024-03-06: https://www.drupal.org/project/drupal/releases/10.2.4
 ENV DRUPAL_VERSION 10.2.4
 
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
 WORKDIR /opt/drupal
 RUN set -eux; \
 	export COMPOSER_HOME="$(mktemp -d)"; \

--- a/10.2/php8.3/apache-bookworm/Dockerfile
+++ b/10.2/php8.3/apache-bookworm/Dockerfile
@@ -69,6 +69,13 @@ COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 # 2024-03-06: https://www.drupal.org/project/drupal/releases/10.2.4
 ENV DRUPAL_VERSION 10.2.4
 
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
 WORKDIR /opt/drupal
 RUN set -eux; \
 	export COMPOSER_HOME="$(mktemp -d)"; \

--- a/10.2/php8.3/apache-bullseye/Dockerfile
+++ b/10.2/php8.3/apache-bullseye/Dockerfile
@@ -69,6 +69,13 @@ COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 # 2024-03-06: https://www.drupal.org/project/drupal/releases/10.2.4
 ENV DRUPAL_VERSION 10.2.4
 
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
 WORKDIR /opt/drupal
 RUN set -eux; \
 	export COMPOSER_HOME="$(mktemp -d)"; \

--- a/10.2/php8.3/fpm-alpine3.18/Dockerfile
+++ b/10.2/php8.3/fpm-alpine3.18/Dockerfile
@@ -58,6 +58,13 @@ COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 # 2024-03-06: https://www.drupal.org/project/drupal/releases/10.2.4
 ENV DRUPAL_VERSION 10.2.4
 
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
 WORKDIR /opt/drupal
 RUN set -eux; \
 	export COMPOSER_HOME="$(mktemp -d)"; \

--- a/10.2/php8.3/fpm-alpine3.19/Dockerfile
+++ b/10.2/php8.3/fpm-alpine3.19/Dockerfile
@@ -58,6 +58,13 @@ COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 # 2024-03-06: https://www.drupal.org/project/drupal/releases/10.2.4
 ENV DRUPAL_VERSION 10.2.4
 
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
 WORKDIR /opt/drupal
 RUN set -eux; \
 	export COMPOSER_HOME="$(mktemp -d)"; \

--- a/10.2/php8.3/fpm-bookworm/Dockerfile
+++ b/10.2/php8.3/fpm-bookworm/Dockerfile
@@ -69,6 +69,13 @@ COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 # 2024-03-06: https://www.drupal.org/project/drupal/releases/10.2.4
 ENV DRUPAL_VERSION 10.2.4
 
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
 WORKDIR /opt/drupal
 RUN set -eux; \
 	export COMPOSER_HOME="$(mktemp -d)"; \

--- a/10.2/php8.3/fpm-bullseye/Dockerfile
+++ b/10.2/php8.3/fpm-bullseye/Dockerfile
@@ -69,6 +69,13 @@ COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 # 2024-03-06: https://www.drupal.org/project/drupal/releases/10.2.4
 ENV DRUPAL_VERSION 10.2.4
 
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
 WORKDIR /opt/drupal
 RUN set -eux; \
 	export COMPOSER_HOME="$(mktemp -d)"; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -93,6 +93,13 @@ COPY --from=composer:{{ .composer.version }} /usr/bin/composer /usr/local/bin/
 ENV DRUPAL_VERSION {{ .version }}
 {{ if has("composer") then ( -}}
 
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
 WORKDIR /opt/drupal
 RUN set -eux; \
 	export COMPOSER_HOME="$(mktemp -d)"; \


### PR DESCRIPTION
Current images fail to build since buildkit doesn't have `/.dockerenv` during build; see [composer source](https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218) for its behavior change based in "being in a container".

Abbreviated failure log:
```console
+ composer create-project --no-interaction drupal/recommended-project:10.1.8 ./
...
  - Installing composer/installers (v2.2.0): Extracting archive
The "composer/installers" plugin was not loaded as plugins are disabled.
  - Installing drupal/core-composer-scaffold (10.1.8): Extracting archive
The "drupal/core-composer-scaffold" plugin was not loaded as plugins are disabled.
  - Installing drupal/core-project-message (10.1.8): Extracting archive
The "drupal/core-project-message" plugin was not loaded as plugins are disabled.
...
No security vulnerability advisories found.
+ chown -R www-data:www-data web/sites web/modules web/themes
chown: web/sites: No such file or directory
chown: web/modules: No such file or directory
chown: web/themes: No such file or directory
```
(In fact, there is no `web` directory at all, see the composer issue below)

See also: 
- https://github.com/moby/buildkit/issues/4503
- https://github.com/composer/composer/issues/11854, https://github.com/composer/composer/issues/11839

---

Setting the fix as an `ENV` so that anything `FROM drupal:10.*` can also benefit from it when building via buildkit.