### PR TITLE
Fix for Drupal calling out missing features; APCu and Output Buffering following a clean installation.

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -51,6 +51,12 @@ RUN set -eux; \
 		zip \
 	; \
 	\
+	# kelvtech-co-uk 18th Oct 2024 - Proposed resolution to the missing drupal features noted in the 'Status Report' following a clean install of the image.
+	pecl install apcu; \
+	echo 'extension=apcu.so' > /usr/local/etc/php/conf.d/docker-php-apcu.ini; \
+	echo 'output_buffering=on' > /usr/local/etc/php/conf.d/docker-php-output-buffering.ini; \
+	# End of PR	
+	\
 {{ if is_alpine then ( -}}
 	runDeps="$( \
 		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \


### PR DESCRIPTION
Hi, this is my first PR to a proper repo and not just my own so please forgive any bad practices.

I noted after clean install Drupal's 'Status Report' was noting some missing features.  After a little digging I found that the 

- Upload Progress complaint should be ignored as per the TL;DR note [here.](https://www.drupal.org/node/793264)
- That Output buffering is discussed [here](https://www.drupal.org/node/3298550) and is now recommended.
- And that APCu is discussed [here](https://www.drupal.org/node/2327507?form=MG0AV3) and to my read suggests its a benefit out of the box.