### PR TITLE
Add upstream recommened setting for output_buffering

### DIFF
--- a/10.4/php8.3/apache-bookworm/Dockerfile
+++ b/10.4/php8.3/apache-bookworm/Dockerfile
@@ -64,6 +64,13 @@ RUN { \
 		echo 'opcache.revalidate_freq=60'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
+# https://www.drupal.org/node/3298550
+# Drupal now recommends sites enable PHP output buffering by default, if PHP is run as a server module
+# e.g. with Apache's mod_php
+RUN { \
+		echo 'output_buffering=true'; \
+	} > /usr/local/etc/php/conf.d/docker-php-drupal-recommended.ini
+
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # 2025-06-06: https://www.drupal.org/project/drupal/releases/10.4.8

--- a/10.4/php8.3/apache-bullseye/Dockerfile
+++ b/10.4/php8.3/apache-bullseye/Dockerfile
@@ -64,6 +64,13 @@ RUN { \
 		echo 'opcache.revalidate_freq=60'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
+# https://www.drupal.org/node/3298550
+# Drupal now recommends sites enable PHP output buffering by default, if PHP is run as a server module
+# e.g. with Apache's mod_php
+RUN { \
+		echo 'output_buffering=true'; \
+	} > /usr/local/etc/php/conf.d/docker-php-drupal-recommended.ini
+
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # 2025-06-06: https://www.drupal.org/project/drupal/releases/10.4.8

--- a/10.4/php8.4/apache-bookworm/Dockerfile
+++ b/10.4/php8.4/apache-bookworm/Dockerfile
@@ -64,6 +64,13 @@ RUN { \
 		echo 'opcache.revalidate_freq=60'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
+# https://www.drupal.org/node/3298550
+# Drupal now recommends sites enable PHP output buffering by default, if PHP is run as a server module
+# e.g. with Apache's mod_php
+RUN { \
+		echo 'output_buffering=true'; \
+	} > /usr/local/etc/php/conf.d/docker-php-drupal-recommended.ini
+
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # 2025-06-06: https://www.drupal.org/project/drupal/releases/10.4.8

--- a/10.4/php8.4/apache-bullseye/Dockerfile
+++ b/10.4/php8.4/apache-bullseye/Dockerfile
@@ -64,6 +64,13 @@ RUN { \
 		echo 'opcache.revalidate_freq=60'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
+# https://www.drupal.org/node/3298550
+# Drupal now recommends sites enable PHP output buffering by default, if PHP is run as a server module
+# e.g. with Apache's mod_php
+RUN { \
+		echo 'output_buffering=true'; \
+	} > /usr/local/etc/php/conf.d/docker-php-drupal-recommended.ini
+
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # 2025-06-06: https://www.drupal.org/project/drupal/releases/10.4.8

--- a/10.5/php8.3/apache-bookworm/Dockerfile
+++ b/10.5/php8.3/apache-bookworm/Dockerfile
@@ -64,6 +64,13 @@ RUN { \
 		echo 'opcache.revalidate_freq=60'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
+# https://www.drupal.org/node/3298550
+# Drupal now recommends sites enable PHP output buffering by default, if PHP is run as a server module
+# e.g. with Apache's mod_php
+RUN { \
+		echo 'output_buffering=true'; \
+	} > /usr/local/etc/php/conf.d/docker-php-drupal-recommended.ini
+
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # 2025-06-19: https://www.drupal.org/project/drupal/releases/10.5.0

--- a/10.5/php8.3/apache-bullseye/Dockerfile
+++ b/10.5/php8.3/apache-bullseye/Dockerfile
@@ -64,6 +64,13 @@ RUN { \
 		echo 'opcache.revalidate_freq=60'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
+# https://www.drupal.org/node/3298550
+# Drupal now recommends sites enable PHP output buffering by default, if PHP is run as a server module
+# e.g. with Apache's mod_php
+RUN { \
+		echo 'output_buffering=true'; \
+	} > /usr/local/etc/php/conf.d/docker-php-drupal-recommended.ini
+
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # 2025-06-19: https://www.drupal.org/project/drupal/releases/10.5.0

--- a/10.5/php8.4/apache-bookworm/Dockerfile
+++ b/10.5/php8.4/apache-bookworm/Dockerfile
@@ -64,6 +64,13 @@ RUN { \
 		echo 'opcache.revalidate_freq=60'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
+# https://www.drupal.org/node/3298550
+# Drupal now recommends sites enable PHP output buffering by default, if PHP is run as a server module
+# e.g. with Apache's mod_php
+RUN { \
+		echo 'output_buffering=true'; \
+	} > /usr/local/etc/php/conf.d/docker-php-drupal-recommended.ini
+
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # 2025-06-19: https://www.drupal.org/project/drupal/releases/10.5.0

--- a/10.5/php8.4/apache-bullseye/Dockerfile
+++ b/10.5/php8.4/apache-bullseye/Dockerfile
@@ -64,6 +64,13 @@ RUN { \
 		echo 'opcache.revalidate_freq=60'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
+# https://www.drupal.org/node/3298550
+# Drupal now recommends sites enable PHP output buffering by default, if PHP is run as a server module
+# e.g. with Apache's mod_php
+RUN { \
+		echo 'output_buffering=true'; \
+	} > /usr/local/etc/php/conf.d/docker-php-drupal-recommended.ini
+
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # 2025-06-19: https://www.drupal.org/project/drupal/releases/10.5.0

--- a/11.1/php8.3/apache-bookworm/Dockerfile
+++ b/11.1/php8.3/apache-bookworm/Dockerfile
@@ -64,6 +64,13 @@ RUN { \
 		echo 'opcache.revalidate_freq=60'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
+# https://www.drupal.org/node/3298550
+# Drupal now recommends sites enable PHP output buffering by default, if PHP is run as a server module
+# e.g. with Apache's mod_php
+RUN { \
+		echo 'output_buffering=true'; \
+	} > /usr/local/etc/php/conf.d/docker-php-drupal-recommended.ini
+
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # 2025-06-05: https://www.drupal.org/project/drupal/releases/11.1.8

--- a/11.1/php8.3/apache-bullseye/Dockerfile
+++ b/11.1/php8.3/apache-bullseye/Dockerfile
@@ -64,6 +64,13 @@ RUN { \
 		echo 'opcache.revalidate_freq=60'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
+# https://www.drupal.org/node/3298550
+# Drupal now recommends sites enable PHP output buffering by default, if PHP is run as a server module
+# e.g. with Apache's mod_php
+RUN { \
+		echo 'output_buffering=true'; \
+	} > /usr/local/etc/php/conf.d/docker-php-drupal-recommended.ini
+
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # 2025-06-05: https://www.drupal.org/project/drupal/releases/11.1.8

--- a/11.1/php8.4/apache-bookworm/Dockerfile
+++ b/11.1/php8.4/apache-bookworm/Dockerfile
@@ -64,6 +64,13 @@ RUN { \
 		echo 'opcache.revalidate_freq=60'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
+# https://www.drupal.org/node/3298550
+# Drupal now recommends sites enable PHP output buffering by default, if PHP is run as a server module
+# e.g. with Apache's mod_php
+RUN { \
+		echo 'output_buffering=true'; \
+	} > /usr/local/etc/php/conf.d/docker-php-drupal-recommended.ini
+
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # 2025-06-05: https://www.drupal.org/project/drupal/releases/11.1.8

--- a/11.1/php8.4/apache-bullseye/Dockerfile
+++ b/11.1/php8.4/apache-bullseye/Dockerfile
@@ -64,6 +64,13 @@ RUN { \
 		echo 'opcache.revalidate_freq=60'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
+# https://www.drupal.org/node/3298550
+# Drupal now recommends sites enable PHP output buffering by default, if PHP is run as a server module
+# e.g. with Apache's mod_php
+RUN { \
+		echo 'output_buffering=true'; \
+	} > /usr/local/etc/php/conf.d/docker-php-drupal-recommended.ini
+
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # 2025-06-05: https://www.drupal.org/project/drupal/releases/11.1.8

--- a/11.2/php8.3/apache-bookworm/Dockerfile
+++ b/11.2/php8.3/apache-bookworm/Dockerfile
@@ -64,6 +64,13 @@ RUN { \
 		echo 'opcache.revalidate_freq=60'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
+# https://www.drupal.org/node/3298550
+# Drupal now recommends sites enable PHP output buffering by default, if PHP is run as a server module
+# e.g. with Apache's mod_php
+RUN { \
+		echo 'output_buffering=true'; \
+	} > /usr/local/etc/php/conf.d/docker-php-drupal-recommended.ini
+
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # 2025-06-19: https://www.drupal.org/project/drupal/releases/11.2.0

--- a/11.2/php8.3/apache-bullseye/Dockerfile
+++ b/11.2/php8.3/apache-bullseye/Dockerfile
@@ -64,6 +64,13 @@ RUN { \
 		echo 'opcache.revalidate_freq=60'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
+# https://www.drupal.org/node/3298550
+# Drupal now recommends sites enable PHP output buffering by default, if PHP is run as a server module
+# e.g. with Apache's mod_php
+RUN { \
+		echo 'output_buffering=true'; \
+	} > /usr/local/etc/php/conf.d/docker-php-drupal-recommended.ini
+
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # 2025-06-19: https://www.drupal.org/project/drupal/releases/11.2.0

--- a/11.2/php8.4/apache-bookworm/Dockerfile
+++ b/11.2/php8.4/apache-bookworm/Dockerfile
@@ -64,6 +64,13 @@ RUN { \
 		echo 'opcache.revalidate_freq=60'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
+# https://www.drupal.org/node/3298550
+# Drupal now recommends sites enable PHP output buffering by default, if PHP is run as a server module
+# e.g. with Apache's mod_php
+RUN { \
+		echo 'output_buffering=true'; \
+	} > /usr/local/etc/php/conf.d/docker-php-drupal-recommended.ini
+
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # 2025-06-19: https://www.drupal.org/project/drupal/releases/11.2.0

--- a/11.2/php8.4/apache-bullseye/Dockerfile
+++ b/11.2/php8.4/apache-bullseye/Dockerfile
@@ -64,6 +64,13 @@ RUN { \
 		echo 'opcache.revalidate_freq=60'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
+# https://www.drupal.org/node/3298550
+# Drupal now recommends sites enable PHP output buffering by default, if PHP is run as a server module
+# e.g. with Apache's mod_php
+RUN { \
+		echo 'output_buffering=true'; \
+	} > /usr/local/etc/php/conf.d/docker-php-drupal-recommended.ini
+
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
 # 2025-06-19: https://www.drupal.org/project/drupal/releases/11.2.0

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -85,6 +85,15 @@ RUN { \
 		echo 'opcache.revalidate_freq=60'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
+{{ if env.variant | startswith("fpm") then "" else ( -}}
+# https://www.drupal.org/node/3298550
+# Drupal now recommends sites enable PHP output buffering by default, if PHP is run as a server module
+# e.g. with Apache's mod_php
+RUN { \
+		echo 'output_buffering=true'; \
+	} > /usr/local/etc/php/conf.d/docker-php-drupal-recommended.ini
+
+{{ ) end -}}
 {{ if has("composer") then ( -}}
 COPY --from=composer:{{ .composer.version }} /usr/bin/composer /usr/local/bin/
 


### PR DESCRIPTION
This just enables `output_buffering` and only in Apache as recommended by Drupal upstream.

> Drupal now recommends sites enable PHP output buffering by default, if PHP is run as a server module, e.g. with Apache's `mod_php`.

Fixes #256
Related to #270/#271