### PR TITLE
Drop Drupal 7 bits (non composer install)

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -94,13 +94,10 @@ RUN { \
 	} > /usr/local/etc/php/conf.d/docker-php-drupal-recommended.ini
 
 {{ ) end -}}
-{{ if has("composer") then ( -}}
 COPY --from=composer:{{ .composer.version }} /usr/bin/composer /usr/local/bin/
 
-{{ ) else "" end -}}
 # {{ .date | strftime("%Y-%m-%d") }}: {{ .notes }}
 ENV DRUPAL_VERSION {{ .version }}
-{{ if has("composer") then ( -}}
 
 # https://github.com/docker-library/drupal/pull/259
 # https://github.com/moby/buildkit/issues/4503
@@ -122,16 +119,5 @@ RUN set -eux; \
 	rm -rf "$COMPOSER_HOME"
 
 ENV PATH=${PATH}:/opt/drupal/vendor/bin
-{{ ) else ( -}}
-ENV DRUPAL_URL {{ .url }}
-ENV DRUPAL_MD5 {{ .md5 }}
-
-RUN set -eux; \
-	curl -fSL "$DRUPAL_URL" -o drupal.tar.gz; \
-	echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c -; \
-	tar -xz --strip-components=1 -f drupal.tar.gz; \
-	rm drupal.tar.gz; \
-	chown -R www-data:www-data sites modules themes
-{{ ) end -}}
 
 # vim:set ft=dockerfile:


### PR DESCRIPTION
Noticed this when doing #289

We could delete `url` and `md5` from `versions.*` but then we'd also have to drop `date` or commits like https://github.com/docker-library/drupal/commit/7eb8d68a4df0cd6315c107f5263fe791ebe31f72 will look odd.