### PR TITLE
Add 3.37 SQLite database driver

### DIFF
--- a/11.1/php8.3/apache-bookworm/Dockerfile
+++ b/11.1/php8.3/apache-bookworm/Dockerfile
@@ -89,6 +89,7 @@ RUN set -eux; \
 	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
 # https://github.com/docker-library/drupal/pull/266#issuecomment-2273985526
 	composer check-platform-reqs; \
+	composer require 'drupal/sqlite337:^1.0@alpha'; \
 	chown -R www-data:www-data web/sites web/modules web/themes; \
 	rmdir /var/www/html; \
 	ln -sf /opt/drupal/web /var/www/html; \

--- a/11.1/php8.3/apache-bullseye/Dockerfile
+++ b/11.1/php8.3/apache-bullseye/Dockerfile
@@ -89,6 +89,7 @@ RUN set -eux; \
 	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
 # https://github.com/docker-library/drupal/pull/266#issuecomment-2273985526
 	composer check-platform-reqs; \
+	composer require 'drupal/sqlite337:^1.0@alpha'; \
 	chown -R www-data:www-data web/sites web/modules web/themes; \
 	rmdir /var/www/html; \
 	ln -sf /opt/drupal/web /var/www/html; \

--- a/11.1/php8.3/fpm-bookworm/Dockerfile
+++ b/11.1/php8.3/fpm-bookworm/Dockerfile
@@ -82,6 +82,7 @@ RUN set -eux; \
 	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
 # https://github.com/docker-library/drupal/pull/266#issuecomment-2273985526
 	composer check-platform-reqs; \
+	composer require 'drupal/sqlite337:^1.0@alpha'; \
 	chown -R www-data:www-data web/sites web/modules web/themes; \
 	rmdir /var/www/html; \
 	ln -sf /opt/drupal/web /var/www/html; \

--- a/11.1/php8.3/fpm-bullseye/Dockerfile
+++ b/11.1/php8.3/fpm-bullseye/Dockerfile
@@ -82,6 +82,7 @@ RUN set -eux; \
 	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
 # https://github.com/docker-library/drupal/pull/266#issuecomment-2273985526
 	composer check-platform-reqs; \
+	composer require 'drupal/sqlite337:^1.0@alpha'; \
 	chown -R www-data:www-data web/sites web/modules web/themes; \
 	rmdir /var/www/html; \
 	ln -sf /opt/drupal/web /var/www/html; \

--- a/11.1/php8.4/apache-bookworm/Dockerfile
+++ b/11.1/php8.4/apache-bookworm/Dockerfile
@@ -89,6 +89,7 @@ RUN set -eux; \
 	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
 # https://github.com/docker-library/drupal/pull/266#issuecomment-2273985526
 	composer check-platform-reqs; \
+	composer require 'drupal/sqlite337:^1.0@alpha'; \
 	chown -R www-data:www-data web/sites web/modules web/themes; \
 	rmdir /var/www/html; \
 	ln -sf /opt/drupal/web /var/www/html; \

--- a/11.1/php8.4/apache-bullseye/Dockerfile
+++ b/11.1/php8.4/apache-bullseye/Dockerfile
@@ -89,6 +89,7 @@ RUN set -eux; \
 	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
 # https://github.com/docker-library/drupal/pull/266#issuecomment-2273985526
 	composer check-platform-reqs; \
+	composer require 'drupal/sqlite337:^1.0@alpha'; \
 	chown -R www-data:www-data web/sites web/modules web/themes; \
 	rmdir /var/www/html; \
 	ln -sf /opt/drupal/web /var/www/html; \

--- a/11.1/php8.4/fpm-bookworm/Dockerfile
+++ b/11.1/php8.4/fpm-bookworm/Dockerfile
@@ -82,6 +82,7 @@ RUN set -eux; \
 	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
 # https://github.com/docker-library/drupal/pull/266#issuecomment-2273985526
 	composer check-platform-reqs; \
+	composer require 'drupal/sqlite337:^1.0@alpha'; \
 	chown -R www-data:www-data web/sites web/modules web/themes; \
 	rmdir /var/www/html; \
 	ln -sf /opt/drupal/web /var/www/html; \

--- a/11.1/php8.4/fpm-bullseye/Dockerfile
+++ b/11.1/php8.4/fpm-bullseye/Dockerfile
@@ -82,6 +82,7 @@ RUN set -eux; \
 	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
 # https://github.com/docker-library/drupal/pull/266#issuecomment-2273985526
 	composer check-platform-reqs; \
+	composer require 'drupal/sqlite337:^1.0@alpha'; \
 	chown -R www-data:www-data web/sites web/modules web/themes; \
 	rmdir /var/www/html; \
 	ln -sf /opt/drupal/web /var/www/html; \

--- a/11.2/php8.3/apache-bookworm/Dockerfile
+++ b/11.2/php8.3/apache-bookworm/Dockerfile
@@ -89,6 +89,7 @@ RUN set -eux; \
 	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
 # https://github.com/docker-library/drupal/pull/266#issuecomment-2273985526
 	composer check-platform-reqs; \
+	composer require 'drupal/sqlite337:^1.0@alpha'; \
 	chown -R www-data:www-data web/sites web/modules web/themes; \
 	rmdir /var/www/html; \
 	ln -sf /opt/drupal/web /var/www/html; \

--- a/11.2/php8.3/apache-bullseye/Dockerfile
+++ b/11.2/php8.3/apache-bullseye/Dockerfile
@@ -89,6 +89,7 @@ RUN set -eux; \
 	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
 # https://github.com/docker-library/drupal/pull/266#issuecomment-2273985526
 	composer check-platform-reqs; \
+	composer require 'drupal/sqlite337:^1.0@alpha'; \
 	chown -R www-data:www-data web/sites web/modules web/themes; \
 	rmdir /var/www/html; \
 	ln -sf /opt/drupal/web /var/www/html; \

--- a/11.2/php8.3/fpm-bookworm/Dockerfile
+++ b/11.2/php8.3/fpm-bookworm/Dockerfile
@@ -82,6 +82,7 @@ RUN set -eux; \
 	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
 # https://github.com/docker-library/drupal/pull/266#issuecomment-2273985526
 	composer check-platform-reqs; \
+	composer require 'drupal/sqlite337:^1.0@alpha'; \
 	chown -R www-data:www-data web/sites web/modules web/themes; \
 	rmdir /var/www/html; \
 	ln -sf /opt/drupal/web /var/www/html; \

--- a/11.2/php8.3/fpm-bullseye/Dockerfile
+++ b/11.2/php8.3/fpm-bullseye/Dockerfile
@@ -82,6 +82,7 @@ RUN set -eux; \
 	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
 # https://github.com/docker-library/drupal/pull/266#issuecomment-2273985526
 	composer check-platform-reqs; \
+	composer require 'drupal/sqlite337:^1.0@alpha'; \
 	chown -R www-data:www-data web/sites web/modules web/themes; \
 	rmdir /var/www/html; \
 	ln -sf /opt/drupal/web /var/www/html; \

--- a/11.2/php8.4/apache-bookworm/Dockerfile
+++ b/11.2/php8.4/apache-bookworm/Dockerfile
@@ -89,6 +89,7 @@ RUN set -eux; \
 	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
 # https://github.com/docker-library/drupal/pull/266#issuecomment-2273985526
 	composer check-platform-reqs; \
+	composer require 'drupal/sqlite337:^1.0@alpha'; \
 	chown -R www-data:www-data web/sites web/modules web/themes; \
 	rmdir /var/www/html; \
 	ln -sf /opt/drupal/web /var/www/html; \

--- a/11.2/php8.4/apache-bullseye/Dockerfile
+++ b/11.2/php8.4/apache-bullseye/Dockerfile
@@ -89,6 +89,7 @@ RUN set -eux; \
 	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
 # https://github.com/docker-library/drupal/pull/266#issuecomment-2273985526
 	composer check-platform-reqs; \
+	composer require 'drupal/sqlite337:^1.0@alpha'; \
 	chown -R www-data:www-data web/sites web/modules web/themes; \
 	rmdir /var/www/html; \
 	ln -sf /opt/drupal/web /var/www/html; \

--- a/11.2/php8.4/fpm-bookworm/Dockerfile
+++ b/11.2/php8.4/fpm-bookworm/Dockerfile
@@ -82,6 +82,7 @@ RUN set -eux; \
 	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
 # https://github.com/docker-library/drupal/pull/266#issuecomment-2273985526
 	composer check-platform-reqs; \
+	composer require 'drupal/sqlite337:^1.0@alpha'; \
 	chown -R www-data:www-data web/sites web/modules web/themes; \
 	rmdir /var/www/html; \
 	ln -sf /opt/drupal/web /var/www/html; \

--- a/11.2/php8.4/fpm-bullseye/Dockerfile
+++ b/11.2/php8.4/fpm-bullseye/Dockerfile
@@ -82,6 +82,7 @@ RUN set -eux; \
 	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
 # https://github.com/docker-library/drupal/pull/266#issuecomment-2273985526
 	composer check-platform-reqs; \
+	composer require 'drupal/sqlite337:^1.0@alpha'; \
 	chown -R www-data:www-data web/sites web/modules web/themes; \
 	rmdir /var/www/html; \
 	ln -sf /opt/drupal/web /var/www/html; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,6 +1,17 @@
 {{
 	def is_alpine:
 		env.variant | index("alpine")
+	;
+	# The SQLite driver that's included in Drupal 11 core requires SQLite 3.45+.
+	# Alpine 3.21 is new enough
+	# https://pkgs.alpinelinux.org/package/v3.21/main/x86_64/sqlite-libs (3.48.0)
+	# Debian Bullseye and Bookworm are not new enough, but Trixie is
+	# https://packages.debian.org/bullseye/libsqlite3-0 (3.34.1)
+	# https://packages.debian.org/bookworm/libsqlite3-0 (3.40.1)
+	# https://packages.debian.org/trixie/libsqlite3-0 (3.46.1)
+	def needs_sqlite_compat:
+		(env.version | startswith("10.") | not)
+		and (env.variant | split("-")[1] | IN("bookworm", "bullseye"))
 -}}
 # https://www.drupal.org/docs/system-requirements/php-requirements
 FROM php:{{ env.phpVersion }}-{{ env.variant }}
@@ -112,6 +123,9 @@ RUN set -eux; \
 	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
 # https://github.com/docker-library/drupal/pull/266#issuecomment-2273985526
 	composer check-platform-reqs; \
+{{ if needs_sqlite_compat then ( -}}
+	composer require 'drupal/sqlite337:^1.0@alpha'; \
+{{ ) else "" end -}}
 	chown -R www-data:www-data web/sites web/modules web/themes; \
 	rmdir /var/www/html; \
 	ln -sf /opt/drupal/web /var/www/html; \


### PR DESCRIPTION

Drupal 11 core requires SQLite 3.45, but Bullseye and Bookworm do not have that, so they need this alternative driver. The alternative SQLite database driver only requires SQLite 3.37. It can be chosen during the site setup wizard.

![image](https://github.com/user-attachments/assets/5b502cb8-6d26-455c-95f1-2ffb98e76d27)

Note that the alternative adapter is version `1.0@alpha` and is provided by a Drupal developer (https://www.drupal.org/project/sqlite337). Being called an "alpha" release gives me pause, so please test that it works for your use cases (and maybe only use it for dev and not prod). It might not see updates, but we are definitely happy to bump the install line when there are.

Fixes #264