### PR TITLE
Update latest aliases

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -2,8 +2,8 @@
 set -Eeuo pipefail
 
 declare -A aliases=(
-	[11.2]='11 latest'
-	[10.5]='10'
+	[11.3]='11 latest'
+	[10.6]='10'
 )
 
 defaultDebianSuite='trixie'


### PR DESCRIPTION
Moving latest for newly released versions. For a shorter diff, I used the proposed library file that already drops 11.1 and 10.4, and moved the RC`s (https://github.com/docker-library/official-images/pull/20512)

<details>
<summary>Diff:</summary>

```diff
$ diff -u <(curl -fsSL https://raw.githubusercontent.com/docker-library/official-images/bf6cae642c7c5cf850a390649f1cd36c9e0db893/library/drupal) <(./generate-stackbrew-library.sh)
--- /dev/fd/63  2025-12-17 10:13:49.144067706 -0800
+++ /dev/fd/62  2025-12-17 10:13:49.144067706 -0800
@@ -1,245 +1,245 @@
-# this file is generated via https://github.com/docker-library/drupal/blob/2ddd0cbb029c3a13f233430b7cd674803d1f4c3b/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/drupal/blob/0864c211e9e8a86cd8f6e5890e8dac246c4c11bb/generate-stackbrew-library.sh

 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/drupal.git

-Tags: 11.3.0-php8.4-apache-trixie, 11.3-php8.4-apache-trixie, 11.3.0-php8.4-apache, 11.3-php8.4-apache, 11.3.0-php8.4, 11.3-php8.4, 11.3.0-apache-trixie, 11.3-apache-trixie, 11.3.0-apache, 11.3-apache, 11.3.0, 11.3
+Tags: 11.3.0-php8.4-apache-trixie, 11.3-php8.4-apache-trixie, 11-php8.4-apache-trixie, php8.4-apache-trixie, 11.3.0-php8.4-apache, 11.3-php8.4-apache, 11-php8.4-apache, php8.4-apache, 11.3.0-php8.4, 11.3-php8.4, 11-php8.4, php8.4, 11.3.0-apache-trixie, 11.3-apache-trixie, 11-apache-trixie, apache-trixie, 11.3.0-apache, 11.3-apache, 11-apache, apache, 11.3.0, 11.3, 11, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 5bf8daf73fcff6ed0201a07b0ed910b979e8b6d9
 Directory: 11.3/php8.4/apache-trixie

-Tags: 11.3.0-php8.4-fpm-trixie, 11.3-php8.4-fpm-trixie, 11.3.0-php8.4-fpm, 11.3-php8.4-fpm, 11.3.0-fpm-trixie, 11.3-fpm-trixie, 11.3.0-fpm, 11.3-fpm
+Tags: 11.3.0-php8.4-fpm-trixie, 11.3-php8.4-fpm-trixie, 11-php8.4-fpm-trixie, php8.4-fpm-trixie, 11.3.0-php8.4-fpm, 11.3-php8.4-fpm, 11-php8.4-fpm, php8.4-fpm, 11.3.0-fpm-trixie, 11.3-fpm-trixie, 11-fpm-trixie, fpm-trixie, 11.3.0-fpm, 11.3-fpm, 11-fpm, fpm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 5bf8daf73fcff6ed0201a07b0ed910b979e8b6d9
 Directory: 11.3/php8.4/fpm-trixie

-Tags: 11.3.0-php8.4-apache-bookworm, 11.3-php8.4-apache-bookworm, 11.3.0-apache-bookworm, 11.3-apache-bookworm
+Tags: 11.3.0-php8.4-apache-bookworm, 11.3-php8.4-apache-bookworm, 11-php8.4-apache-bookworm, php8.4-apache-bookworm, 11.3.0-apache-bookworm, 11.3-apache-bookworm, 11-apache-bookworm, apache-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 5bf8daf73fcff6ed0201a07b0ed910b979e8b6d9
 Directory: 11.3/php8.4/apache-bookworm

-Tags: 11.3.0-php8.4-fpm-bookworm, 11.3-php8.4-fpm-bookworm, 11.3.0-fpm-bookworm, 11.3-fpm-bookworm
+Tags: 11.3.0-php8.4-fpm-bookworm, 11.3-php8.4-fpm-bookworm, 11-php8.4-fpm-bookworm, php8.4-fpm-bookworm, 11.3.0-fpm-bookworm, 11.3-fpm-bookworm, 11-fpm-bookworm, fpm-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 5bf8daf73fcff6ed0201a07b0ed910b979e8b6d9
 Directory: 11.3/php8.4/fpm-bookworm

-Tags: 11.3.0-php8.4-fpm-alpine3.23, 11.3-php8.4-fpm-alpine3.23, 11.3.0-php8.4-fpm-alpine, 11.3-php8.4-fpm-alpine, 11.3.0-fpm-alpine3.23, 11.3-fpm-alpine3.23, 11.3.0-fpm-alpine, 11.3-fpm-alpine
+Tags: 11.3.0-php8.4-fpm-alpine3.23, 11.3-php8.4-fpm-alpine3.23, 11-php8.4-fpm-alpine3.23, php8.4-fpm-alpine3.23, 11.3.0-php8.4-fpm-alpine, 11.3-php8.4-fpm-alpine, 11-php8.4-fpm-alpine, php8.4-fpm-alpine, 11.3.0-fpm-alpine3.23, 11.3-fpm-alpine3.23, 11-fpm-alpine3.23, fpm-alpine3.23, 11.3.0-fpm-alpine, 11.3-fpm-alpine, 11-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 5bf8daf73fcff6ed0201a07b0ed910b979e8b6d9
 Directory: 11.3/php8.4/fpm-alpine3.23

-Tags: 11.3.0-php8.4-fpm-alpine3.22, 11.3-php8.4-fpm-alpine3.22, 11.3.0-fpm-alpine3.22, 11.3-fpm-alpine3.22
+Tags: 11.3.0-php8.4-fpm-alpine3.22, 11.3-php8.4-fpm-alpine3.22, 11-php8.4-fpm-alpine3.22, php8.4-fpm-alpine3.22, 11.3.0-fpm-alpine3.22, 11.3-fpm-alpine3.22, 11-fpm-alpine3.22, fpm-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 5bf8daf73fcff6ed0201a07b0ed910b979e8b6d9
 Directory: 11.3/php8.4/fpm-alpine3.22

-Tags: 11.3.0-php8.3-apache-trixie, 11.3-php8.3-apache-trixie, 11.3.0-php8.3-apache, 11.3-php8.3-apache, 11.3.0-php8.3, 11.3-php8.3
+Tags: 11.3.0-php8.3-apache-trixie, 11.3-php8.3-apache-trixie, 11-php8.3-apache-trixie, php8.3-apache-trixie, 11.3.0-php8.3-apache, 11.3-php8.3-apache, 11-php8.3-apache, php8.3-apache, 11.3.0-php8.3, 11.3-php8.3, 11-php8.3, php8.3
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 5bf8daf73fcff6ed0201a07b0ed910b979e8b6d9
 Directory: 11.3/php8.3/apache-trixie

-Tags: 11.3.0-php8.3-fpm-trixie, 11.3-php8.3-fpm-trixie, 11.3.0-php8.3-fpm, 11.3-php8.3-fpm
+Tags: 11.3.0-php8.3-fpm-trixie, 11.3-php8.3-fpm-trixie, 11-php8.3-fpm-trixie, php8.3-fpm-trixie, 11.3.0-php8.3-fpm, 11.3-php8.3-fpm, 11-php8.3-fpm, php8.3-fpm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 5bf8daf73fcff6ed0201a07b0ed910b979e8b6d9
 Directory: 11.3/php8.3/fpm-trixie

-Tags: 11.3.0-php8.3-apache-bookworm, 11.3-php8.3-apache-bookworm
+Tags: 11.3.0-php8.3-apache-bookworm, 11.3-php8.3-apache-bookworm, 11-php8.3-apache-bookworm, php8.3-apache-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 5bf8daf73fcff6ed0201a07b0ed910b979e8b6d9
 Directory: 11.3/php8.3/apache-bookworm

-Tags: 11.3.0-php8.3-fpm-bookworm, 11.3-php8.3-fpm-bookworm
+Tags: 11.3.0-php8.3-fpm-bookworm, 11.3-php8.3-fpm-bookworm, 11-php8.3-fpm-bookworm, php8.3-fpm-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 5bf8daf73fcff6ed0201a07b0ed910b979e8b6d9
 Directory: 11.3/php8.3/fpm-bookworm

-Tags: 11.3.0-php8.3-fpm-alpine3.23, 11.3-php8.3-fpm-alpine3.23, 11.3.0-php8.3-fpm-alpine, 11.3-php8.3-fpm-alpine
+Tags: 11.3.0-php8.3-fpm-alpine3.23, 11.3-php8.3-fpm-alpine3.23, 11-php8.3-fpm-alpine3.23, php8.3-fpm-alpine3.23, 11.3.0-php8.3-fpm-alpine, 11.3-php8.3-fpm-alpine, 11-php8.3-fpm-alpine, php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 5bf8daf73fcff6ed0201a07b0ed910b979e8b6d9
 Directory: 11.3/php8.3/fpm-alpine3.23

-Tags: 11.3.0-php8.3-fpm-alpine3.22, 11.3-php8.3-fpm-alpine3.22
+Tags: 11.3.0-php8.3-fpm-alpine3.22, 11.3-php8.3-fpm-alpine3.22, 11-php8.3-fpm-alpine3.22, php8.3-fpm-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 5bf8daf73fcff6ed0201a07b0ed910b979e8b6d9
 Directory: 11.3/php8.3/fpm-alpine3.22

-Tags: 11.2.10-php8.4-apache-trixie, 11.2-php8.4-apache-trixie, 11-php8.4-apache-trixie, php8.4-apache-trixie, 11.2.10-php8.4-apache, 11.2-php8.4-apache, 11-php8.4-apache, php8.4-apache, 11.2.10-php8.4, 11.2-php8.4, 11-php8.4, php8.4, 11.2.10-apache-trixie, 11.2-apache-trixie, 11-apache-trixie, apache-trixie, 11.2.10-apache, 11.2-apache, 11-apache, apache, 11.2.10, 11.2, 11, latest
+Tags: 11.2.10-php8.4-apache-trixie, 11.2-php8.4-apache-trixie, 11.2.10-php8.4-apache, 11.2-php8.4-apache, 11.2.10-php8.4, 11.2-php8.4, 11.2.10-apache-trixie, 11.2-apache-trixie, 11.2.10-apache, 11.2-apache, 11.2.10, 11.2
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: a0d9b553e28d816166cd59f3971b6c6c6b11351b
 Directory: 11.2/php8.4/apache-trixie

-Tags: 11.2.10-php8.4-fpm-trixie, 11.2-php8.4-fpm-trixie, 11-php8.4-fpm-trixie, php8.4-fpm-trixie, 11.2.10-php8.4-fpm, 11.2-php8.4-fpm, 11-php8.4-fpm, php8.4-fpm, 11.2.10-fpm-trixie, 11.2-fpm-trixie, 11-fpm-trixie, fpm-trixie, 11.2.10-fpm, 11.2-fpm, 11-fpm, fpm
+Tags: 11.2.10-php8.4-fpm-trixie, 11.2-php8.4-fpm-trixie, 11.2.10-php8.4-fpm, 11.2-php8.4-fpm, 11.2.10-fpm-trixie, 11.2-fpm-trixie, 11.2.10-fpm, 11.2-fpm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: a0d9b553e28d816166cd59f3971b6c6c6b11351b
 Directory: 11.2/php8.4/fpm-trixie

-Tags: 11.2.10-php8.4-apache-bookworm, 11.2-php8.4-apache-bookworm, 11-php8.4-apache-bookworm, php8.4-apache-bookworm, 11.2.10-apache-bookworm, 11.2-apache-bookworm, 11-apache-bookworm, apache-bookworm
+Tags: 11.2.10-php8.4-apache-bookworm, 11.2-php8.4-apache-bookworm, 11.2.10-apache-bookworm, 11.2-apache-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a0d9b553e28d816166cd59f3971b6c6c6b11351b
 Directory: 11.2/php8.4/apache-bookworm

-Tags: 11.2.10-php8.4-fpm-bookworm, 11.2-php8.4-fpm-bookworm, 11-php8.4-fpm-bookworm, php8.4-fpm-bookworm, 11.2.10-fpm-bookworm, 11.2-fpm-bookworm, 11-fpm-bookworm, fpm-bookworm
+Tags: 11.2.10-php8.4-fpm-bookworm, 11.2-php8.4-fpm-bookworm, 11.2.10-fpm-bookworm, 11.2-fpm-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a0d9b553e28d816166cd59f3971b6c6c6b11351b
 Directory: 11.2/php8.4/fpm-bookworm

-Tags: 11.2.10-php8.4-fpm-alpine3.23, 11.2-php8.4-fpm-alpine3.23, 11-php8.4-fpm-alpine3.23, php8.4-fpm-alpine3.23, 11.2.10-php8.4-fpm-alpine, 11.2-php8.4-fpm-alpine, 11-php8.4-fpm-alpine, php8.4-fpm-alpine, 11.2.10-fpm-alpine3.23, 11.2-fpm-alpine3.23, 11-fpm-alpine3.23, fpm-alpine3.23, 11.2.10-fpm-alpine, 11.2-fpm-alpine, 11-fpm-alpine, fpm-alpine
+Tags: 11.2.10-php8.4-fpm-alpine3.23, 11.2-php8.4-fpm-alpine3.23, 11.2.10-php8.4-fpm-alpine, 11.2-php8.4-fpm-alpine, 11.2.10-fpm-alpine3.23, 11.2-fpm-alpine3.23, 11.2.10-fpm-alpine, 11.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: a0d9b553e28d816166cd59f3971b6c6c6b11351b
 Directory: 11.2/php8.4/fpm-alpine3.23

-Tags: 11.2.10-php8.4-fpm-alpine3.22, 11.2-php8.4-fpm-alpine3.22, 11-php8.4-fpm-alpine3.22, php8.4-fpm-alpine3.22, 11.2.10-fpm-alpine3.22, 11.2-fpm-alpine3.22, 11-fpm-alpine3.22, fpm-alpine3.22
+Tags: 11.2.10-php8.4-fpm-alpine3.22, 11.2-php8.4-fpm-alpine3.22, 11.2.10-fpm-alpine3.22, 11.2-fpm-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: a0d9b553e28d816166cd59f3971b6c6c6b11351b
 Directory: 11.2/php8.4/fpm-alpine3.22

-Tags: 11.2.10-php8.3-apache-trixie, 11.2-php8.3-apache-trixie, 11-php8.3-apache-trixie, php8.3-apache-trixie, 11.2.10-php8.3-apache, 11.2-php8.3-apache, 11-php8.3-apache, php8.3-apache, 11.2.10-php8.3, 11.2-php8.3, 11-php8.3, php8.3
+Tags: 11.2.10-php8.3-apache-trixie, 11.2-php8.3-apache-trixie, 11.2.10-php8.3-apache, 11.2-php8.3-apache, 11.2.10-php8.3, 11.2-php8.3
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: a0d9b553e28d816166cd59f3971b6c6c6b11351b
 Directory: 11.2/php8.3/apache-trixie

-Tags: 11.2.10-php8.3-fpm-trixie, 11.2-php8.3-fpm-trixie, 11-php8.3-fpm-trixie, php8.3-fpm-trixie, 11.2.10-php8.3-fpm, 11.2-php8.3-fpm, 11-php8.3-fpm, php8.3-fpm
+Tags: 11.2.10-php8.3-fpm-trixie, 11.2-php8.3-fpm-trixie, 11.2.10-php8.3-fpm, 11.2-php8.3-fpm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: a0d9b553e28d816166cd59f3971b6c6c6b11351b
 Directory: 11.2/php8.3/fpm-trixie

-Tags: 11.2.10-php8.3-apache-bookworm, 11.2-php8.3-apache-bookworm, 11-php8.3-apache-bookworm, php8.3-apache-bookworm
+Tags: 11.2.10-php8.3-apache-bookworm, 11.2-php8.3-apache-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a0d9b553e28d816166cd59f3971b6c6c6b11351b
 Directory: 11.2/php8.3/apache-bookworm

-Tags: 11.2.10-php8.3-fpm-bookworm, 11.2-php8.3-fpm-bookworm, 11-php8.3-fpm-bookworm, php8.3-fpm-bookworm
+Tags: 11.2.10-php8.3-fpm-bookworm, 11.2-php8.3-fpm-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a0d9b553e28d816166cd59f3971b6c6c6b11351b
 Directory: 11.2/php8.3/fpm-bookworm

-Tags: 11.2.10-php8.3-fpm-alpine3.23, 11.2-php8.3-fpm-alpine3.23, 11-php8.3-fpm-alpine3.23, php8.3-fpm-alpine3.23, 11.2.10-php8.3-fpm-alpine, 11.2-php8.3-fpm-alpine, 11-php8.3-fpm-alpine, php8.3-fpm-alpine
+Tags: 11.2.10-php8.3-fpm-alpine3.23, 11.2-php8.3-fpm-alpine3.23, 11.2.10-php8.3-fpm-alpine, 11.2-php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: a0d9b553e28d816166cd59f3971b6c6c6b11351b
 Directory: 11.2/php8.3/fpm-alpine3.23

-Tags: 11.2.10-php8.3-fpm-alpine3.22, 11.2-php8.3-fpm-alpine3.22, 11-php8.3-fpm-alpine3.22, php8.3-fpm-alpine3.22
+Tags: 11.2.10-php8.3-fpm-alpine3.22, 11.2-php8.3-fpm-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: a0d9b553e28d816166cd59f3971b6c6c6b11351b
 Directory: 11.2/php8.3/fpm-alpine3.22

-Tags: 10.6.0-php8.4-apache-trixie, 10.6-php8.4-apache-trixie, 10.6.0-php8.4-apache, 10.6-php8.4-apache, 10.6.0-php8.4, 10.6-php8.4, 10.6.0-apache-trixie, 10.6-apache-trixie, 10.6.0-apache, 10.6-apache, 10.6.0, 10.6
+Tags: 10.6.0-php8.4-apache-trixie, 10.6-php8.4-apache-trixie, 10-php8.4-apache-trixie, 10.6.0-php8.4-apache, 10.6-php8.4-apache, 10-php8.4-apache, 10.6.0-php8.4, 10.6-php8.4, 10-php8.4, 10.6.0-apache-trixie, 10.6-apache-trixie, 10-apache-trixie, 10.6.0-apache, 10.6-apache, 10-apache, 10.6.0, 10.6, 10
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: da19a4b07dc0160d1701df58155231c4b5da7dee
 Directory: 10.6/php8.4/apache-trixie

-Tags: 10.6.0-php8.4-fpm-trixie, 10.6-php8.4-fpm-trixie, 10.6.0-php8.4-fpm, 10.6-php8.4-fpm, 10.6.0-fpm-trixie, 10.6-fpm-trixie, 10.6.0-fpm, 10.6-fpm
+Tags: 10.6.0-php8.4-fpm-trixie, 10.6-php8.4-fpm-trixie, 10-php8.4-fpm-trixie, 10.6.0-php8.4-fpm, 10.6-php8.4-fpm, 10-php8.4-fpm, 10.6.0-fpm-trixie, 10.6-fpm-trixie, 10-fpm-trixie, 10.6.0-fpm, 10.6-fpm, 10-fpm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: da19a4b07dc0160d1701df58155231c4b5da7dee
 Directory: 10.6/php8.4/fpm-trixie

-Tags: 10.6.0-php8.4-apache-bookworm, 10.6-php8.4-apache-bookworm, 10.6.0-apache-bookworm, 10.6-apache-bookworm
+Tags: 10.6.0-php8.4-apache-bookworm, 10.6-php8.4-apache-bookworm, 10-php8.4-apache-bookworm, 10.6.0-apache-bookworm, 10.6-apache-bookworm, 10-apache-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: da19a4b07dc0160d1701df58155231c4b5da7dee
 Directory: 10.6/php8.4/apache-bookworm

-Tags: 10.6.0-php8.4-fpm-bookworm, 10.6-php8.4-fpm-bookworm, 10.6.0-fpm-bookworm, 10.6-fpm-bookworm
+Tags: 10.6.0-php8.4-fpm-bookworm, 10.6-php8.4-fpm-bookworm, 10-php8.4-fpm-bookworm, 10.6.0-fpm-bookworm, 10.6-fpm-bookworm, 10-fpm-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: da19a4b07dc0160d1701df58155231c4b5da7dee
 Directory: 10.6/php8.4/fpm-bookworm

-Tags: 10.6.0-php8.4-fpm-alpine3.23, 10.6-php8.4-fpm-alpine3.23, 10.6.0-php8.4-fpm-alpine, 10.6-php8.4-fpm-alpine, 10.6.0-fpm-alpine3.23, 10.6-fpm-alpine3.23, 10.6.0-fpm-alpine, 10.6-fpm-alpine
+Tags: 10.6.0-php8.4-fpm-alpine3.23, 10.6-php8.4-fpm-alpine3.23, 10-php8.4-fpm-alpine3.23, 10.6.0-php8.4-fpm-alpine, 10.6-php8.4-fpm-alpine, 10-php8.4-fpm-alpine, 10.6.0-fpm-alpine3.23, 10.6-fpm-alpine3.23, 10-fpm-alpine3.23, 10.6.0-fpm-alpine, 10.6-fpm-alpine, 10-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: da19a4b07dc0160d1701df58155231c4b5da7dee
 Directory: 10.6/php8.4/fpm-alpine3.23

-Tags: 10.6.0-php8.4-fpm-alpine3.22, 10.6-php8.4-fpm-alpine3.22, 10.6.0-fpm-alpine3.22, 10.6-fpm-alpine3.22
+Tags: 10.6.0-php8.4-fpm-alpine3.22, 10.6-php8.4-fpm-alpine3.22, 10-php8.4-fpm-alpine3.22, 10.6.0-fpm-alpine3.22, 10.6-fpm-alpine3.22, 10-fpm-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: da19a4b07dc0160d1701df58155231c4b5da7dee
 Directory: 10.6/php8.4/fpm-alpine3.22

-Tags: 10.6.0-php8.3-apache-trixie, 10.6-php8.3-apache-trixie, 10.6.0-php8.3-apache, 10.6-php8.3-apache, 10.6.0-php8.3, 10.6-php8.3
+Tags: 10.6.0-php8.3-apache-trixie, 10.6-php8.3-apache-trixie, 10-php8.3-apache-trixie, 10.6.0-php8.3-apache, 10.6-php8.3-apache, 10-php8.3-apache, 10.6.0-php8.3, 10.6-php8.3, 10-php8.3
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: da19a4b07dc0160d1701df58155231c4b5da7dee
 Directory: 10.6/php8.3/apache-trixie

-Tags: 10.6.0-php8.3-fpm-trixie, 10.6-php8.3-fpm-trixie, 10.6.0-php8.3-fpm, 10.6-php8.3-fpm
+Tags: 10.6.0-php8.3-fpm-trixie, 10.6-php8.3-fpm-trixie, 10-php8.3-fpm-trixie, 10.6.0-php8.3-fpm, 10.6-php8.3-fpm, 10-php8.3-fpm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: da19a4b07dc0160d1701df58155231c4b5da7dee
 Directory: 10.6/php8.3/fpm-trixie

-Tags: 10.6.0-php8.3-apache-bookworm, 10.6-php8.3-apache-bookworm
+Tags: 10.6.0-php8.3-apache-bookworm, 10.6-php8.3-apache-bookworm, 10-php8.3-apache-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: da19a4b07dc0160d1701df58155231c4b5da7dee
 Directory: 10.6/php8.3/apache-bookworm

-Tags: 10.6.0-php8.3-fpm-bookworm, 10.6-php8.3-fpm-bookworm
+Tags: 10.6.0-php8.3-fpm-bookworm, 10.6-php8.3-fpm-bookworm, 10-php8.3-fpm-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: da19a4b07dc0160d1701df58155231c4b5da7dee
 Directory: 10.6/php8.3/fpm-bookworm

-Tags: 10.6.0-php8.3-fpm-alpine3.23, 10.6-php8.3-fpm-alpine3.23, 10.6.0-php8.3-fpm-alpine, 10.6-php8.3-fpm-alpine
+Tags: 10.6.0-php8.3-fpm-alpine3.23, 10.6-php8.3-fpm-alpine3.23, 10-php8.3-fpm-alpine3.23, 10.6.0-php8.3-fpm-alpine, 10.6-php8.3-fpm-alpine, 10-php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: da19a4b07dc0160d1701df58155231c4b5da7dee
 Directory: 10.6/php8.3/fpm-alpine3.23

-Tags: 10.6.0-php8.3-fpm-alpine3.22, 10.6-php8.3-fpm-alpine3.22
+Tags: 10.6.0-php8.3-fpm-alpine3.22, 10.6-php8.3-fpm-alpine3.22, 10-php8.3-fpm-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: da19a4b07dc0160d1701df58155231c4b5da7dee
 Directory: 10.6/php8.3/fpm-alpine3.22

-Tags: 10.5.8-php8.4-apache-trixie, 10.5-php8.4-apache-trixie, 10-php8.4-apache-trixie, 10.5.8-php8.4-apache, 10.5-php8.4-apache, 10-php8.4-apache, 10.5.8-php8.4, 10.5-php8.4, 10-php8.4, 10.5.8-apache-trixie, 10.5-apache-trixie, 10-apache-trixie, 10.5.8-apache, 10.5-apache, 10-apache, 10.5.8, 10.5, 10
+Tags: 10.5.8-php8.4-apache-trixie, 10.5-php8.4-apache-trixie, 10.5.8-php8.4-apache, 10.5-php8.4-apache, 10.5.8-php8.4, 10.5-php8.4, 10.5.8-apache-trixie, 10.5-apache-trixie, 10.5.8-apache, 10.5-apache, 10.5.8, 10.5
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 4a684115b7703293a77e383381f19a23b2212b3d
 Directory: 10.5/php8.4/apache-trixie

-Tags: 10.5.8-php8.4-fpm-trixie, 10.5-php8.4-fpm-trixie, 10-php8.4-fpm-trixie, 10.5.8-php8.4-fpm, 10.5-php8.4-fpm, 10-php8.4-fpm, 10.5.8-fpm-trixie, 10.5-fpm-trixie, 10-fpm-trixie, 10.5.8-fpm, 10.5-fpm, 10-fpm
+Tags: 10.5.8-php8.4-fpm-trixie, 10.5-php8.4-fpm-trixie, 10.5.8-php8.4-fpm, 10.5-php8.4-fpm, 10.5.8-fpm-trixie, 10.5-fpm-trixie, 10.5.8-fpm, 10.5-fpm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 4a684115b7703293a77e383381f19a23b2212b3d
 Directory: 10.5/php8.4/fpm-trixie

-Tags: 10.5.8-php8.4-apache-bookworm, 10.5-php8.4-apache-bookworm, 10-php8.4-apache-bookworm, 10.5.8-apache-bookworm, 10.5-apache-bookworm, 10-apache-bookworm
+Tags: 10.5.8-php8.4-apache-bookworm, 10.5-php8.4-apache-bookworm, 10.5.8-apache-bookworm, 10.5-apache-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4a684115b7703293a77e383381f19a23b2212b3d
 Directory: 10.5/php8.4/apache-bookworm

-Tags: 10.5.8-php8.4-fpm-bookworm, 10.5-php8.4-fpm-bookworm, 10-php8.4-fpm-bookworm, 10.5.8-fpm-bookworm, 10.5-fpm-bookworm, 10-fpm-bookworm
+Tags: 10.5.8-php8.4-fpm-bookworm, 10.5-php8.4-fpm-bookworm, 10.5.8-fpm-bookworm, 10.5-fpm-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4a684115b7703293a77e383381f19a23b2212b3d
 Directory: 10.5/php8.4/fpm-bookworm

-Tags: 10.5.8-php8.4-fpm-alpine3.23, 10.5-php8.4-fpm-alpine3.23, 10-php8.4-fpm-alpine3.23, 10.5.8-php8.4-fpm-alpine, 10.5-php8.4-fpm-alpine, 10-php8.4-fpm-alpine, 10.5.8-fpm-alpine3.23, 10.5-fpm-alpine3.23, 10-fpm-alpine3.23, 10.5.8-fpm-alpine, 10.5-fpm-alpine, 10-fpm-alpine
+Tags: 10.5.8-php8.4-fpm-alpine3.23, 10.5-php8.4-fpm-alpine3.23, 10.5.8-php8.4-fpm-alpine, 10.5-php8.4-fpm-alpine, 10.5.8-fpm-alpine3.23, 10.5-fpm-alpine3.23, 10.5.8-fpm-alpine, 10.5-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 4a684115b7703293a77e383381f19a23b2212b3d
 Directory: 10.5/php8.4/fpm-alpine3.23

-Tags: 10.5.8-php8.4-fpm-alpine3.22, 10.5-php8.4-fpm-alpine3.22, 10-php8.4-fpm-alpine3.22, 10.5.8-fpm-alpine3.22, 10.5-fpm-alpine3.22, 10-fpm-alpine3.22
+Tags: 10.5.8-php8.4-fpm-alpine3.22, 10.5-php8.4-fpm-alpine3.22, 10.5.8-fpm-alpine3.22, 10.5-fpm-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 4a684115b7703293a77e383381f19a23b2212b3d
 Directory: 10.5/php8.4/fpm-alpine3.22

-Tags: 10.5.8-php8.3-apache-trixie, 10.5-php8.3-apache-trixie, 10-php8.3-apache-trixie, 10.5.8-php8.3-apache, 10.5-php8.3-apache, 10-php8.3-apache, 10.5.8-php8.3, 10.5-php8.3, 10-php8.3
+Tags: 10.5.8-php8.3-apache-trixie, 10.5-php8.3-apache-trixie, 10.5.8-php8.3-apache, 10.5-php8.3-apache, 10.5.8-php8.3, 10.5-php8.3
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 4a684115b7703293a77e383381f19a23b2212b3d
 Directory: 10.5/php8.3/apache-trixie

-Tags: 10.5.8-php8.3-fpm-trixie, 10.5-php8.3-fpm-trixie, 10-php8.3-fpm-trixie, 10.5.8-php8.3-fpm, 10.5-php8.3-fpm, 10-php8.3-fpm
+Tags: 10.5.8-php8.3-fpm-trixie, 10.5-php8.3-fpm-trixie, 10.5.8-php8.3-fpm, 10.5-php8.3-fpm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 4a684115b7703293a77e383381f19a23b2212b3d
 Directory: 10.5/php8.3/fpm-trixie

-Tags: 10.5.8-php8.3-apache-bookworm, 10.5-php8.3-apache-bookworm, 10-php8.3-apache-bookworm
+Tags: 10.5.8-php8.3-apache-bookworm, 10.5-php8.3-apache-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4a684115b7703293a77e383381f19a23b2212b3d
 Directory: 10.5/php8.3/apache-bookworm

-Tags: 10.5.8-php8.3-fpm-bookworm, 10.5-php8.3-fpm-bookworm, 10-php8.3-fpm-bookworm
+Tags: 10.5.8-php8.3-fpm-bookworm, 10.5-php8.3-fpm-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4a684115b7703293a77e383381f19a23b2212b3d
 Directory: 10.5/php8.3/fpm-bookworm

-Tags: 10.5.8-php8.3-fpm-alpine3.23, 10.5-php8.3-fpm-alpine3.23, 10-php8.3-fpm-alpine3.23, 10.5.8-php8.3-fpm-alpine, 10.5-php8.3-fpm-alpine, 10-php8.3-fpm-alpine
+Tags: 10.5.8-php8.3-fpm-alpine3.23, 10.5-php8.3-fpm-alpine3.23, 10.5.8-php8.3-fpm-alpine, 10.5-php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 4a684115b7703293a77e383381f19a23b2212b3d
 Directory: 10.5/php8.3/fpm-alpine3.23

-Tags: 10.5.8-php8.3-fpm-alpine3.22, 10.5-php8.3-fpm-alpine3.22, 10-php8.3-fpm-alpine3.22
+Tags: 10.5.8-php8.3-fpm-alpine3.22, 10.5-php8.3-fpm-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 4a684115b7703293a77e383381f19a23b2212b3d
 Directory: 10.5/php8.3/fpm-alpine3.22
```

</details>