### PR TITLE
Add drupal 11.4 beta1

### DIFF
--- a/10.5/php8.3/fpm-alpine3.24/Dockerfile
+++ b/10.5/php8.3/fpm-alpine3.24/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # https://www.drupal.org/docs/system-requirements/php-requirements
-FROM php:8.4-fpm-alpine3.22
+FROM php:8.3-fpm-alpine3.24
 
 # install the PHP extensions we need
 RUN set -eux; \
@@ -54,8 +54,8 @@ RUN { \
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
-# 2026-05-28: https://www.drupal.org/project/drupal/releases/11.3.11
-ENV DRUPAL_VERSION 11.3.11
+# 2026-05-28: https://www.drupal.org/project/drupal/releases/10.5.11
+ENV DRUPAL_VERSION 10.5.11
 
 # https://github.com/docker-library/drupal/pull/259
 # https://github.com/moby/buildkit/issues/4503

--- a/10.5/php8.4/fpm-alpine3.24/Dockerfile
+++ b/10.5/php8.4/fpm-alpine3.24/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # https://www.drupal.org/docs/system-requirements/php-requirements
-FROM php:8.4-fpm-alpine3.22
+FROM php:8.4-fpm-alpine3.24
 
 # install the PHP extensions we need
 RUN set -eux; \
@@ -54,8 +54,8 @@ RUN { \
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
-# 2026-05-28: https://www.drupal.org/project/drupal/releases/11.2.13
-ENV DRUPAL_VERSION 11.2.13
+# 2026-05-28: https://www.drupal.org/project/drupal/releases/10.5.11
+ENV DRUPAL_VERSION 10.5.11
 
 # https://github.com/docker-library/drupal/pull/259
 # https://github.com/moby/buildkit/issues/4503

--- a/10.6/php8.3/fpm-alpine3.24/Dockerfile
+++ b/10.6/php8.3/fpm-alpine3.24/Dockerfile
@@ -1,0 +1,81 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+# https://www.drupal.org/docs/system-requirements/php-requirements
+FROM php:8.3-fpm-alpine3.24
+
+# install the PHP extensions we need
+RUN set -eux; \
+	\
+	apk add --no-cache --virtual .build-deps \
+		coreutils \
+		freetype-dev \
+		libjpeg-turbo-dev \
+		libpng-dev \
+		libwebp-dev \
+		libzip-dev \
+# postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
+		postgresql-dev \
+	; \
+	\
+	docker-php-ext-configure gd \
+		--with-freetype \
+		--with-jpeg=/usr/include \
+		--with-webp \
+	; \
+	\
+	docker-php-ext-install -j "$(nproc)" \
+		gd \
+		pdo_mysql \
+		pdo_pgsql \
+		zip \
+	; \
+	\
+	runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)"; \
+	apk add --no-network --virtual .drupal-phpexts-rundeps $runDeps; \
+	apk del --no-network .build-deps
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=60'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
+
+# 2026-05-28: https://www.drupal.org/project/drupal/releases/10.6.10
+ENV DRUPAL_VERSION 10.6.10
+
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
+WORKDIR /opt/drupal
+RUN set -eux; \
+	export COMPOSER_HOME="$(mktemp -d)"; \
+	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
+# https://github.com/docker-library/drupal/pull/266#issuecomment-2273985526
+	composer check-platform-reqs; \
+	chown -R www-data:www-data web/sites web/modules web/themes; \
+	rmdir /var/www/html; \
+	ln -sf /opt/drupal/web /var/www/html; \
+	# delete composer cache
+	rm -rf "$COMPOSER_HOME"
+
+ENV PATH=${PATH}:/opt/drupal/vendor/bin
+
+# vim:set ft=dockerfile:

--- a/10.6/php8.4/fpm-alpine3.24/Dockerfile
+++ b/10.6/php8.4/fpm-alpine3.24/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # https://www.drupal.org/docs/system-requirements/php-requirements
-FROM php:8.4-fpm-alpine3.22
+FROM php:8.4-fpm-alpine3.24
 
 # install the PHP extensions we need
 RUN set -eux; \
@@ -54,8 +54,8 @@ RUN { \
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
-# 2026-05-28: https://www.drupal.org/project/drupal/releases/10.5.11
-ENV DRUPAL_VERSION 10.5.11
+# 2026-05-28: https://www.drupal.org/project/drupal/releases/10.6.10
+ENV DRUPAL_VERSION 10.6.10
 
 # https://github.com/docker-library/drupal/pull/259
 # https://github.com/moby/buildkit/issues/4503

--- a/11.2/php8.3/fpm-alpine3.24/Dockerfile
+++ b/11.2/php8.3/fpm-alpine3.24/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # https://www.drupal.org/docs/system-requirements/php-requirements
-FROM php:8.3-fpm-alpine3.22
+FROM php:8.3-fpm-alpine3.24
 
 # install the PHP extensions we need
 RUN set -eux; \

--- a/11.2/php8.4/fpm-alpine3.24/Dockerfile
+++ b/11.2/php8.4/fpm-alpine3.24/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # https://www.drupal.org/docs/system-requirements/php-requirements
-FROM php:8.5-fpm-alpine3.22
+FROM php:8.4-fpm-alpine3.24
 
 # install the PHP extensions we need
 RUN set -eux; \
@@ -54,8 +54,8 @@ RUN { \
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
-# 2026-05-28: https://www.drupal.org/project/drupal/releases/11.3.11
-ENV DRUPAL_VERSION 11.3.11
+# 2026-05-28: https://www.drupal.org/project/drupal/releases/11.2.13
+ENV DRUPAL_VERSION 11.2.13
 
 # https://github.com/docker-library/drupal/pull/259
 # https://github.com/moby/buildkit/issues/4503

--- a/11.3/php8.4/fpm-alpine3.24/Dockerfile
+++ b/11.3/php8.4/fpm-alpine3.24/Dockerfile
@@ -1,0 +1,81 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+# https://www.drupal.org/docs/system-requirements/php-requirements
+FROM php:8.4-fpm-alpine3.24
+
+# install the PHP extensions we need
+RUN set -eux; \
+	\
+	apk add --no-cache --virtual .build-deps \
+		coreutils \
+		freetype-dev \
+		libjpeg-turbo-dev \
+		libpng-dev \
+		libwebp-dev \
+		libzip-dev \
+# postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
+		postgresql-dev \
+	; \
+	\
+	docker-php-ext-configure gd \
+		--with-freetype \
+		--with-jpeg=/usr/include \
+		--with-webp \
+	; \
+	\
+	docker-php-ext-install -j "$(nproc)" \
+		gd \
+		pdo_mysql \
+		pdo_pgsql \
+		zip \
+	; \
+	\
+	runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)"; \
+	apk add --no-network --virtual .drupal-phpexts-rundeps $runDeps; \
+	apk del --no-network .build-deps
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=60'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
+
+# 2026-05-28: https://www.drupal.org/project/drupal/releases/11.3.11
+ENV DRUPAL_VERSION 11.3.11
+
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
+WORKDIR /opt/drupal
+RUN set -eux; \
+	export COMPOSER_HOME="$(mktemp -d)"; \
+	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
+# https://github.com/docker-library/drupal/pull/266#issuecomment-2273985526
+	composer check-platform-reqs; \
+	chown -R www-data:www-data web/sites web/modules web/themes; \
+	rmdir /var/www/html; \
+	ln -sf /opt/drupal/web /var/www/html; \
+	# delete composer cache
+	rm -rf "$COMPOSER_HOME"
+
+ENV PATH=${PATH}:/opt/drupal/vendor/bin
+
+# vim:set ft=dockerfile:

--- a/11.3/php8.5/fpm-alpine3.24/Dockerfile
+++ b/11.3/php8.5/fpm-alpine3.24/Dockerfile
@@ -1,0 +1,81 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+# https://www.drupal.org/docs/system-requirements/php-requirements
+FROM php:8.5-fpm-alpine3.24
+
+# install the PHP extensions we need
+RUN set -eux; \
+	\
+	apk add --no-cache --virtual .build-deps \
+		coreutils \
+		freetype-dev \
+		libjpeg-turbo-dev \
+		libpng-dev \
+		libwebp-dev \
+		libzip-dev \
+# postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
+		postgresql-dev \
+	; \
+	\
+	docker-php-ext-configure gd \
+		--with-freetype \
+		--with-jpeg=/usr/include \
+		--with-webp \
+	; \
+	\
+	docker-php-ext-install -j "$(nproc)" \
+		gd \
+		pdo_mysql \
+		pdo_pgsql \
+		zip \
+	; \
+	\
+	runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)"; \
+	apk add --no-network --virtual .drupal-phpexts-rundeps $runDeps; \
+	apk del --no-network .build-deps
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=60'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
+
+# 2026-05-28: https://www.drupal.org/project/drupal/releases/11.3.11
+ENV DRUPAL_VERSION 11.3.11
+
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
+WORKDIR /opt/drupal
+RUN set -eux; \
+	export COMPOSER_HOME="$(mktemp -d)"; \
+	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
+# https://github.com/docker-library/drupal/pull/266#issuecomment-2273985526
+	composer check-platform-reqs; \
+	chown -R www-data:www-data web/sites web/modules web/themes; \
+	rmdir /var/www/html; \
+	ln -sf /opt/drupal/web /var/www/html; \
+	# delete composer cache
+	rm -rf "$COMPOSER_HOME"
+
+ENV PATH=${PATH}:/opt/drupal/vendor/bin
+
+# vim:set ft=dockerfile:

--- a/11.4-rc/php8.4/apache-bookworm/Dockerfile
+++ b/11.4-rc/php8.4/apache-bookworm/Dockerfile
@@ -1,0 +1,99 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+# https://www.drupal.org/docs/system-requirements/php-requirements
+FROM php:8.4-apache-bookworm
+
+# install the PHP extensions we need
+RUN set -eux; \
+	\
+	if command -v a2enmod; then \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
+	fi; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libfreetype6-dev \
+		libjpeg-dev \
+		libpng-dev \
+		libpq-dev \
+		libwebp-dev \
+		libzip-dev \
+	; \
+	\
+	docker-php-ext-configure gd \
+		--with-freetype \
+		--with-jpeg=/usr \
+		--with-webp \
+	; \
+	\
+	docker-php-ext-install -j "$(nproc)" \
+		gd \
+		pdo_mysql \
+		pdo_pgsql \
+		zip \
+	; \
+	\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); printf "*%s\n", so }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=60'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+
+# https://www.drupal.org/node/3298550
+# Drupal now recommends sites enable PHP output buffering by default, if PHP is run as a server module
+# e.g. with Apache's mod_php
+RUN { \
+		echo 'output_buffering=true'; \
+	} > /usr/local/etc/php/conf.d/docker-php-drupal-recommended.ini
+
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
+
+# 2026-06-03: https://www.drupal.org/project/drupal/releases/11.4.0-beta1
+ENV DRUPAL_VERSION 11.4.0-beta1
+
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
+WORKDIR /opt/drupal
+RUN set -eux; \
+	export COMPOSER_HOME="$(mktemp -d)"; \
+	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
+# https://github.com/docker-library/drupal/pull/266#issuecomment-2273985526
+	composer check-platform-reqs; \
+	chown -R www-data:www-data web/sites web/modules web/themes; \
+	rmdir /var/www/html; \
+	ln -sf /opt/drupal/web /var/www/html; \
+	# delete composer cache
+	rm -rf "$COMPOSER_HOME"
+
+ENV PATH=${PATH}:/opt/drupal/vendor/bin
+
+# vim:set ft=dockerfile:

--- a/11.4-rc/php8.4/apache-trixie/Dockerfile
+++ b/11.4-rc/php8.4/apache-trixie/Dockerfile
@@ -1,0 +1,99 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+# https://www.drupal.org/docs/system-requirements/php-requirements
+FROM php:8.4-apache-trixie
+
+# install the PHP extensions we need
+RUN set -eux; \
+	\
+	if command -v a2enmod; then \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
+	fi; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libfreetype6-dev \
+		libjpeg-dev \
+		libpng-dev \
+		libpq-dev \
+		libwebp-dev \
+		libzip-dev \
+	; \
+	\
+	docker-php-ext-configure gd \
+		--with-freetype \
+		--with-jpeg=/usr \
+		--with-webp \
+	; \
+	\
+	docker-php-ext-install -j "$(nproc)" \
+		gd \
+		pdo_mysql \
+		pdo_pgsql \
+		zip \
+	; \
+	\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); printf "*%s\n", so }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=60'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+
+# https://www.drupal.org/node/3298550
+# Drupal now recommends sites enable PHP output buffering by default, if PHP is run as a server module
+# e.g. with Apache's mod_php
+RUN { \
+		echo 'output_buffering=true'; \
+	} > /usr/local/etc/php/conf.d/docker-php-drupal-recommended.ini
+
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
+
+# 2026-06-03: https://www.drupal.org/project/drupal/releases/11.4.0-beta1
+ENV DRUPAL_VERSION 11.4.0-beta1
+
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
+WORKDIR /opt/drupal
+RUN set -eux; \
+	export COMPOSER_HOME="$(mktemp -d)"; \
+	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
+# https://github.com/docker-library/drupal/pull/266#issuecomment-2273985526
+	composer check-platform-reqs; \
+	chown -R www-data:www-data web/sites web/modules web/themes; \
+	rmdir /var/www/html; \
+	ln -sf /opt/drupal/web /var/www/html; \
+	# delete composer cache
+	rm -rf "$COMPOSER_HOME"
+
+ENV PATH=${PATH}:/opt/drupal/vendor/bin
+
+# vim:set ft=dockerfile:

--- a/11.4-rc/php8.4/fpm-alpine3.23/Dockerfile
+++ b/11.4-rc/php8.4/fpm-alpine3.23/Dockerfile
@@ -1,0 +1,81 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+# https://www.drupal.org/docs/system-requirements/php-requirements
+FROM php:8.4-fpm-alpine3.23
+
+# install the PHP extensions we need
+RUN set -eux; \
+	\
+	apk add --no-cache --virtual .build-deps \
+		coreutils \
+		freetype-dev \
+		libjpeg-turbo-dev \
+		libpng-dev \
+		libwebp-dev \
+		libzip-dev \
+# postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
+		postgresql-dev \
+	; \
+	\
+	docker-php-ext-configure gd \
+		--with-freetype \
+		--with-jpeg=/usr/include \
+		--with-webp \
+	; \
+	\
+	docker-php-ext-install -j "$(nproc)" \
+		gd \
+		pdo_mysql \
+		pdo_pgsql \
+		zip \
+	; \
+	\
+	runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)"; \
+	apk add --no-network --virtual .drupal-phpexts-rundeps $runDeps; \
+	apk del --no-network .build-deps
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=60'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
+
+# 2026-06-03: https://www.drupal.org/project/drupal/releases/11.4.0-beta1
+ENV DRUPAL_VERSION 11.4.0-beta1
+
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
+WORKDIR /opt/drupal
+RUN set -eux; \
+	export COMPOSER_HOME="$(mktemp -d)"; \
+	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
+# https://github.com/docker-library/drupal/pull/266#issuecomment-2273985526
+	composer check-platform-reqs; \
+	chown -R www-data:www-data web/sites web/modules web/themes; \
+	rmdir /var/www/html; \
+	ln -sf /opt/drupal/web /var/www/html; \
+	# delete composer cache
+	rm -rf "$COMPOSER_HOME"
+
+ENV PATH=${PATH}:/opt/drupal/vendor/bin
+
+# vim:set ft=dockerfile:

--- a/11.4-rc/php8.4/fpm-alpine3.24/Dockerfile
+++ b/11.4-rc/php8.4/fpm-alpine3.24/Dockerfile
@@ -1,0 +1,81 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+# https://www.drupal.org/docs/system-requirements/php-requirements
+FROM php:8.4-fpm-alpine3.24
+
+# install the PHP extensions we need
+RUN set -eux; \
+	\
+	apk add --no-cache --virtual .build-deps \
+		coreutils \
+		freetype-dev \
+		libjpeg-turbo-dev \
+		libpng-dev \
+		libwebp-dev \
+		libzip-dev \
+# postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
+		postgresql-dev \
+	; \
+	\
+	docker-php-ext-configure gd \
+		--with-freetype \
+		--with-jpeg=/usr/include \
+		--with-webp \
+	; \
+	\
+	docker-php-ext-install -j "$(nproc)" \
+		gd \
+		pdo_mysql \
+		pdo_pgsql \
+		zip \
+	; \
+	\
+	runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)"; \
+	apk add --no-network --virtual .drupal-phpexts-rundeps $runDeps; \
+	apk del --no-network .build-deps
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=60'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
+
+# 2026-06-03: https://www.drupal.org/project/drupal/releases/11.4.0-beta1
+ENV DRUPAL_VERSION 11.4.0-beta1
+
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
+WORKDIR /opt/drupal
+RUN set -eux; \
+	export COMPOSER_HOME="$(mktemp -d)"; \
+	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
+# https://github.com/docker-library/drupal/pull/266#issuecomment-2273985526
+	composer check-platform-reqs; \
+	chown -R www-data:www-data web/sites web/modules web/themes; \
+	rmdir /var/www/html; \
+	ln -sf /opt/drupal/web /var/www/html; \
+	# delete composer cache
+	rm -rf "$COMPOSER_HOME"
+
+ENV PATH=${PATH}:/opt/drupal/vendor/bin
+
+# vim:set ft=dockerfile:

--- a/11.4-rc/php8.4/fpm-bookworm/Dockerfile
+++ b/11.4-rc/php8.4/fpm-bookworm/Dockerfile
@@ -1,0 +1,92 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+# https://www.drupal.org/docs/system-requirements/php-requirements
+FROM php:8.4-fpm-bookworm
+
+# install the PHP extensions we need
+RUN set -eux; \
+	\
+	if command -v a2enmod; then \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
+	fi; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libfreetype6-dev \
+		libjpeg-dev \
+		libpng-dev \
+		libpq-dev \
+		libwebp-dev \
+		libzip-dev \
+	; \
+	\
+	docker-php-ext-configure gd \
+		--with-freetype \
+		--with-jpeg=/usr \
+		--with-webp \
+	; \
+	\
+	docker-php-ext-install -j "$(nproc)" \
+		gd \
+		pdo_mysql \
+		pdo_pgsql \
+		zip \
+	; \
+	\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); printf "*%s\n", so }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=60'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
+
+# 2026-06-03: https://www.drupal.org/project/drupal/releases/11.4.0-beta1
+ENV DRUPAL_VERSION 11.4.0-beta1
+
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
+WORKDIR /opt/drupal
+RUN set -eux; \
+	export COMPOSER_HOME="$(mktemp -d)"; \
+	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
+# https://github.com/docker-library/drupal/pull/266#issuecomment-2273985526
+	composer check-platform-reqs; \
+	chown -R www-data:www-data web/sites web/modules web/themes; \
+	rmdir /var/www/html; \
+	ln -sf /opt/drupal/web /var/www/html; \
+	# delete composer cache
+	rm -rf "$COMPOSER_HOME"
+
+ENV PATH=${PATH}:/opt/drupal/vendor/bin
+
+# vim:set ft=dockerfile:

--- a/11.4-rc/php8.4/fpm-trixie/Dockerfile
+++ b/11.4-rc/php8.4/fpm-trixie/Dockerfile
@@ -1,0 +1,92 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+# https://www.drupal.org/docs/system-requirements/php-requirements
+FROM php:8.4-fpm-trixie
+
+# install the PHP extensions we need
+RUN set -eux; \
+	\
+	if command -v a2enmod; then \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
+	fi; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libfreetype6-dev \
+		libjpeg-dev \
+		libpng-dev \
+		libpq-dev \
+		libwebp-dev \
+		libzip-dev \
+	; \
+	\
+	docker-php-ext-configure gd \
+		--with-freetype \
+		--with-jpeg=/usr \
+		--with-webp \
+	; \
+	\
+	docker-php-ext-install -j "$(nproc)" \
+		gd \
+		pdo_mysql \
+		pdo_pgsql \
+		zip \
+	; \
+	\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); printf "*%s\n", so }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=60'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
+
+# 2026-06-03: https://www.drupal.org/project/drupal/releases/11.4.0-beta1
+ENV DRUPAL_VERSION 11.4.0-beta1
+
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
+WORKDIR /opt/drupal
+RUN set -eux; \
+	export COMPOSER_HOME="$(mktemp -d)"; \
+	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
+# https://github.com/docker-library/drupal/pull/266#issuecomment-2273985526
+	composer check-platform-reqs; \
+	chown -R www-data:www-data web/sites web/modules web/themes; \
+	rmdir /var/www/html; \
+	ln -sf /opt/drupal/web /var/www/html; \
+	# delete composer cache
+	rm -rf "$COMPOSER_HOME"
+
+ENV PATH=${PATH}:/opt/drupal/vendor/bin
+
+# vim:set ft=dockerfile:

--- a/11.4-rc/php8.5/apache-bookworm/Dockerfile
+++ b/11.4-rc/php8.5/apache-bookworm/Dockerfile
@@ -5,25 +5,31 @@
 #
 
 # https://www.drupal.org/docs/system-requirements/php-requirements
-FROM php:8.3-fpm-alpine3.22
+FROM php:8.5-apache-bookworm
 
 # install the PHP extensions we need
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .build-deps \
-		coreutils \
-		freetype-dev \
-		libjpeg-turbo-dev \
+	if command -v a2enmod; then \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
+	fi; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libfreetype6-dev \
+		libjpeg-dev \
 		libpng-dev \
+		libpq-dev \
 		libwebp-dev \
 		libzip-dev \
-# postgresql-dev is needed for https://bugs.alpinelinux.org/issues/3642
-		postgresql-dev \
 	; \
 	\
 	docker-php-ext-configure gd \
 		--with-freetype \
-		--with-jpeg=/usr/include \
+		--with-jpeg=/usr \
 		--with-webp \
 	; \
 	\
@@ -34,14 +40,19 @@ RUN set -eux; \
 		zip \
 	; \
 	\
-	runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
-			| tr ',' '\n' \
-			| sort -u \
-			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-	)"; \
-	apk add --no-network --virtual .drupal-phpexts-rundeps $runDeps; \
-	apk del --no-network .build-deps
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); printf "*%s\n", so }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php
@@ -52,10 +63,17 @@ RUN { \
 		echo 'opcache.revalidate_freq=60'; \
 	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
+# https://www.drupal.org/node/3298550
+# Drupal now recommends sites enable PHP output buffering by default, if PHP is run as a server module
+# e.g. with Apache's mod_php
+RUN { \
+		echo 'output_buffering=true'; \
+	} > /usr/local/etc/php/conf.d/docker-php-drupal-recommended.ini
+
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
-# 2026-05-28: https://www.drupal.org/project/drupal/releases/10.5.11
-ENV DRUPAL_VERSION 10.5.11
+# 2026-06-03: https://www.drupal.org/project/drupal/releases/11.4.0-beta1
+ENV DRUPAL_VERSION 11.4.0-beta1
 
 # https://github.com/docker-library/drupal/pull/259
 # https://github.com/moby/buildkit/issues/4503

--- a/11.4-rc/php8.5/apache-trixie/Dockerfile
+++ b/11.4-rc/php8.5/apache-trixie/Dockerfile
@@ -1,0 +1,99 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+# https://www.drupal.org/docs/system-requirements/php-requirements
+FROM php:8.5-apache-trixie
+
+# install the PHP extensions we need
+RUN set -eux; \
+	\
+	if command -v a2enmod; then \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
+	fi; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libfreetype6-dev \
+		libjpeg-dev \
+		libpng-dev \
+		libpq-dev \
+		libwebp-dev \
+		libzip-dev \
+	; \
+	\
+	docker-php-ext-configure gd \
+		--with-freetype \
+		--with-jpeg=/usr \
+		--with-webp \
+	; \
+	\
+	docker-php-ext-install -j "$(nproc)" \
+		gd \
+		pdo_mysql \
+		pdo_pgsql \
+		zip \
+	; \
+	\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); printf "*%s\n", so }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=60'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+
+# https://www.drupal.org/node/3298550
+# Drupal now recommends sites enable PHP output buffering by default, if PHP is run as a server module
+# e.g. with Apache's mod_php
+RUN { \
+		echo 'output_buffering=true'; \
+	} > /usr/local/etc/php/conf.d/docker-php-drupal-recommended.ini
+
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
+
+# 2026-06-03: https://www.drupal.org/project/drupal/releases/11.4.0-beta1
+ENV DRUPAL_VERSION 11.4.0-beta1
+
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
+WORKDIR /opt/drupal
+RUN set -eux; \
+	export COMPOSER_HOME="$(mktemp -d)"; \
+	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
+# https://github.com/docker-library/drupal/pull/266#issuecomment-2273985526
+	composer check-platform-reqs; \
+	chown -R www-data:www-data web/sites web/modules web/themes; \
+	rmdir /var/www/html; \
+	ln -sf /opt/drupal/web /var/www/html; \
+	# delete composer cache
+	rm -rf "$COMPOSER_HOME"
+
+ENV PATH=${PATH}:/opt/drupal/vendor/bin
+
+# vim:set ft=dockerfile:

--- a/11.4-rc/php8.5/fpm-alpine3.23/Dockerfile
+++ b/11.4-rc/php8.5/fpm-alpine3.23/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # https://www.drupal.org/docs/system-requirements/php-requirements
-FROM php:8.4-fpm-alpine3.22
+FROM php:8.5-fpm-alpine3.23
 
 # install the PHP extensions we need
 RUN set -eux; \
@@ -54,8 +54,8 @@ RUN { \
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
-# 2026-05-28: https://www.drupal.org/project/drupal/releases/10.6.10
-ENV DRUPAL_VERSION 10.6.10
+# 2026-06-03: https://www.drupal.org/project/drupal/releases/11.4.0-beta1
+ENV DRUPAL_VERSION 11.4.0-beta1
 
 # https://github.com/docker-library/drupal/pull/259
 # https://github.com/moby/buildkit/issues/4503

--- a/11.4-rc/php8.5/fpm-alpine3.24/Dockerfile
+++ b/11.4-rc/php8.5/fpm-alpine3.24/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # https://www.drupal.org/docs/system-requirements/php-requirements
-FROM php:8.3-fpm-alpine3.22
+FROM php:8.5-fpm-alpine3.24
 
 # install the PHP extensions we need
 RUN set -eux; \
@@ -54,8 +54,8 @@ RUN { \
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
 
-# 2026-05-28: https://www.drupal.org/project/drupal/releases/10.6.10
-ENV DRUPAL_VERSION 10.6.10
+# 2026-06-03: https://www.drupal.org/project/drupal/releases/11.4.0-beta1
+ENV DRUPAL_VERSION 11.4.0-beta1
 
 # https://github.com/docker-library/drupal/pull/259
 # https://github.com/moby/buildkit/issues/4503

--- a/11.4-rc/php8.5/fpm-bookworm/Dockerfile
+++ b/11.4-rc/php8.5/fpm-bookworm/Dockerfile
@@ -1,0 +1,92 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+# https://www.drupal.org/docs/system-requirements/php-requirements
+FROM php:8.5-fpm-bookworm
+
+# install the PHP extensions we need
+RUN set -eux; \
+	\
+	if command -v a2enmod; then \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
+	fi; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libfreetype6-dev \
+		libjpeg-dev \
+		libpng-dev \
+		libpq-dev \
+		libwebp-dev \
+		libzip-dev \
+	; \
+	\
+	docker-php-ext-configure gd \
+		--with-freetype \
+		--with-jpeg=/usr \
+		--with-webp \
+	; \
+	\
+	docker-php-ext-install -j "$(nproc)" \
+		gd \
+		pdo_mysql \
+		pdo_pgsql \
+		zip \
+	; \
+	\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); printf "*%s\n", so }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=60'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
+
+# 2026-06-03: https://www.drupal.org/project/drupal/releases/11.4.0-beta1
+ENV DRUPAL_VERSION 11.4.0-beta1
+
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
+WORKDIR /opt/drupal
+RUN set -eux; \
+	export COMPOSER_HOME="$(mktemp -d)"; \
+	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
+# https://github.com/docker-library/drupal/pull/266#issuecomment-2273985526
+	composer check-platform-reqs; \
+	chown -R www-data:www-data web/sites web/modules web/themes; \
+	rmdir /var/www/html; \
+	ln -sf /opt/drupal/web /var/www/html; \
+	# delete composer cache
+	rm -rf "$COMPOSER_HOME"
+
+ENV PATH=${PATH}:/opt/drupal/vendor/bin
+
+# vim:set ft=dockerfile:

--- a/11.4-rc/php8.5/fpm-trixie/Dockerfile
+++ b/11.4-rc/php8.5/fpm-trixie/Dockerfile
@@ -1,0 +1,92 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+# https://www.drupal.org/docs/system-requirements/php-requirements
+FROM php:8.5-fpm-trixie
+
+# install the PHP extensions we need
+RUN set -eux; \
+	\
+	if command -v a2enmod; then \
+# https://github.com/drupal/drupal/blob/d91d8d0a6d3ffe5f0b6dde8c2fbe81404843edc5/.htaccess (references both mod_expires and mod_rewrite explicitly)
+		a2enmod expires rewrite; \
+	fi; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libfreetype6-dev \
+		libjpeg-dev \
+		libpng-dev \
+		libpq-dev \
+		libwebp-dev \
+		libzip-dev \
+	; \
+	\
+	docker-php-ext-configure gd \
+		--with-freetype \
+		--with-jpeg=/usr \
+		--with-webp \
+	; \
+	\
+	docker-php-ext-install -j "$(nproc)" \
+		gd \
+		pdo_mysql \
+		pdo_pgsql \
+		zip \
+	; \
+	\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); printf "*%s\n", so }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=60'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/
+
+# 2026-06-03: https://www.drupal.org/project/drupal/releases/11.4.0-beta1
+ENV DRUPAL_VERSION 11.4.0-beta1
+
+# https://github.com/docker-library/drupal/pull/259
+# https://github.com/moby/buildkit/issues/4503
+# https://github.com/composer/composer/issues/11839
+# https://github.com/composer/composer/issues/11854
+# https://github.com/composer/composer/blob/94fe2945456df51e122a492b8d14ac4b54c1d2ce/src/Composer/Console/Application.php#L217-L218
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
+WORKDIR /opt/drupal
+RUN set -eux; \
+	export COMPOSER_HOME="$(mktemp -d)"; \
+	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
+# https://github.com/docker-library/drupal/pull/266#issuecomment-2273985526
+	composer check-platform-reqs; \
+	chown -R www-data:www-data web/sites web/modules web/themes; \
+	rmdir /var/www/html; \
+	ln -sf /opt/drupal/web /var/www/html; \
+	# delete composer cache
+	rm -rf "$COMPOSER_HOME"
+
+ENV PATH=${PATH}:/opt/drupal/vendor/bin
+
+# vim:set ft=dockerfile:

--- a/versions.json
+++ b/versions.json
@@ -1,4 +1,27 @@
 {
+  "11.4-rc": {
+    "version": "11.4.0-beta1",
+    "url": "https://ftp.drupal.org/files/projects/drupal-11.4.0-beta1.tar.gz",
+    "md5": "79cbb7ced77eb131bda8ecd04588a920",
+    "date": 1780487672,
+    "notes": "https://www.drupal.org/project/drupal/releases/11.4.0-beta1",
+    "phpVersions": [
+      "8.5",
+      "8.4"
+    ],
+    "variants": [
+      "apache-trixie",
+      "fpm-trixie",
+      "apache-bookworm",
+      "fpm-bookworm",
+      "fpm-alpine3.24",
+      "fpm-alpine3.23"
+    ],
+    "composer": {
+      "version": "2"
+    }
+  },
+  "11.4": null,
   "11.3": {
     "version": "11.3.11",
     "url": "https://ftp.drupal.org/files/projects/drupal-11.3.11.tar.gz",
@@ -14,8 +37,8 @@
       "fpm-trixie",
       "apache-bookworm",
       "fpm-bookworm",
-      "fpm-alpine3.23",
-      "fpm-alpine3.22"
+      "fpm-alpine3.24",
+      "fpm-alpine3.23"
     ],
     "composer": {
       "version": "2"
@@ -36,8 +59,8 @@
       "fpm-trixie",
       "apache-bookworm",
       "fpm-bookworm",
-      "fpm-alpine3.23",
-      "fpm-alpine3.22"
+      "fpm-alpine3.24",
+      "fpm-alpine3.23"
     ],
     "composer": {
       "version": "2"
@@ -58,8 +81,8 @@
       "fpm-trixie",
       "apache-bookworm",
       "fpm-bookworm",
-      "fpm-alpine3.23",
-      "fpm-alpine3.22"
+      "fpm-alpine3.24",
+      "fpm-alpine3.23"
     ],
     "composer": {
       "version": "2"
@@ -80,8 +103,8 @@
       "fpm-trixie",
       "apache-bookworm",
       "fpm-bookworm",
-      "fpm-alpine3.23",
-      "fpm-alpine3.22"
+      "fpm-alpine3.24",
+      "fpm-alpine3.23"
     ],
     "composer": {
       "version": "2"

--- a/versions.sh
+++ b/versions.sh
@@ -133,8 +133,8 @@ for version in "${versions[@]}"; do
 			variants: [
 				"trixie",
 				"bookworm",
+				"alpine3.24",
 				"alpine3.23",
-				"alpine3.22",
 				empty
 				| if startswith("alpine") then empty else
 						"apache-" + .


### PR DESCRIPTION
https://www.drupal.org/project/drupal/releases/11.4.0-beta1

Also migrate Alpine versions, drop `3.22` and add `3.24`. These two changes are in one PR since just the 11.4 beta addition would fail with `tag not found in manifest for "php": "8.3-fpm-alpine3.22"` in `generate-stackbrew-library.sh` without the Alpine migration.

Builds will likely fail until PHP images are fully pushed: https://github.com/docker-library/official-images/pull/21643