### PR TITLE
Bump latest 11

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -2,7 +2,7 @@
 set -Eeuo pipefail
 
 declare -A aliases=(
-	[11.3]='11 latest'
+	[11.4]='11 latest'
 	[10.6]='10'
 )
 


### PR DESCRIPTION
Now that 11.4 is no longer a pre-release, it should be latest.

https://www.drupal.org/project/drupal/releases/11.4.0